### PR TITLE
Bake in additional dependencies

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -53,6 +53,12 @@
       - gcc-c++
       - python-pip
       - jq
+      - bc
+      - podman
+      - python3
+      - pipenv
+      - figlet
+      - parallel
 
 - name: Install awscli
   pip:


### PR DESCRIPTION
This is an effort to make sure all the packages used by post-install
are installed on the orchestration host to rely less on the AMI. The
orchestration host after this change just needs keys and ansible installed
to run the install/post-steps.