### PR TITLE
Dont require sudo when reading ssh public key

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -125,6 +125,7 @@
   slurp:
     src: "{{openshift_install_ssh_pub_key_file}}"
   delegate_to: localhost
+  become: false
   register: install_ssh_pub_key
 
 - name: Setup install-config.yaml


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>