### PR TITLE
Replace the clients with the binaries extracted

### DIFF
--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -71,6 +71,8 @@
       oc adm release extract --tools {{ openshift_install_release_image_override }}
       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
       chmod +x openshift-install
+      cp oc /usr/local/bin/oc
+      cp kubectl /usr/local/bin/kubectl
 
   when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
 


### PR DESCRIPTION
This commit replaces the oc and kubectl binaries on the host running
the installer with the ones extracted from the release image to make
sure the server version matches the client.

Fixes #133 