### PR TITLE
Updating scale_ci_deploy_directory to take dynamic_deploy_path if alr…

### DIFF
--- a/OCP-4.X/clean-on-osp.yml
+++ b/OCP-4.X/clean-on-osp.yml
@@ -3,9 +3,9 @@
 # Playbook to uninstall OCP 4 on OSP and clean OSP environment
 #
 
-- name: Get scale_ci_deploy directory
+- name: Get scale-ci-deploy directory
   set_fact:
-    scale_ci_deploy_directory: "{{ lookup('env', 'dynamic_deploy_path') | default('scale-ci-deploy', true) }}"
+    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
 
 - name: Uninstall OCP 4 on OSP and cleanup OSP resources
   hosts: orchestration

--- a/OCP-4.X/roles/cerberus_install/tasks/main.yml
+++ b/OCP-4.X/roles/cerberus_install/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Get scale_ci_deploy directory
+- name: Get scale-ci-deploy directory
   set_fact:
-    scale_ci_deploy_directory: "{{ lookup('env', 'dynamic_deploy_path') | default('scale-ci-deploy', true) }}"
+    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
 
 - name: Generate cerberus config file
   template:

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -9,9 +9,9 @@
 # * Install cluster
 #
 
-- name: Get scale_ci_deploy directory
+- name: Get scale-ci-deploy directory
   set_fact:
-    scale_ci_deploy_directory: "{{ lookup('env', 'dynamic_deploy_path') | default('scale-ci-deploy', true) }}"
+    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
 
 - name: Create {{ scale_ci_deploy_directory }} directories
   file:

--- a/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
@@ -3,9 +3,9 @@
 # Clean up cluster
 #
 
-- name: Get scale_ci_deploy directory
+- name: Get scale-ci-deploy directory
   set_fact:
-    scale_ci_deploy_directory: "{{ lookup('env', 'dynamic_deploy_path') | default('scale-ci-deploy', true) }}"
+    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
 
 - name: Check if a cluster is running
   stat:

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Get scale-ci-deploy directory
   set_fact:
-    scale_ci_deploy_directory: "{{ lookup('env', 'dynamic_deploy_path') | default('scale-ci-deploy', true) }}"
+    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
 
 - name: Get cluster name
   shell: |


### PR DESCRIPTION
…eady set in a previous play

Previiusly tthe dynamic_deploy_path ansible var was ignored if set in a previously run play (ie during a full install)