### PR TITLE
Fix dynamic deploy path

### DIFF
--- a/OCP-4.X/clean-on-osp.yml
+++ b/OCP-4.X/clean-on-osp.yml
@@ -3,10 +3,6 @@
 # Playbook to uninstall OCP 4 on OSP and clean OSP environment
 #
 
-- name: Get scale-ci-deploy directory
-  set_fact:
-    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
-
 - name: Uninstall OCP 4 on OSP and cleanup OSP resources
   hosts: orchestration
   gather_facts: true
@@ -22,8 +18,8 @@
     - name: Destroy OCP cluster using openshift-install on OSP
       shell: |
         set -o pipefail
-        cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/
-        export OS_CLIENT_CONFIG_FILE={{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/clouds.yml
+        cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/
+        export OS_CLIENT_CONFIG_FILE={{ ansible_user_dir }}/{{ dynamic_deploy_path }}/clouds.yml
         bin/openshift-install destroy cluster --log-level=debug
       ignore_errors: true
 

--- a/OCP-4.X/deploy-cluster.yml
+++ b/OCP-4.X/deploy-cluster.yml
@@ -11,9 +11,26 @@
   vars_files:
     - vars/install-common-vars.yml
   pre_tasks:
+
     - name: Include platform variables
       include_vars:
         file: "vars/install-on-{{ platform }}.yml"
+
+    - name: Set dynamic scale-ci-deploy path
+      set_fact:
+        dynamic_deploy_path: "{% if lookup('env', 'DYNAMIC_DEPLOY_PATH') %}{{ lookup('env', 'DYNAMIC_DEPLOY_PATH') }}{% else %}scale-ci-{{ openshift_cluster_name }}-{{ platform }}{% endif %}"
+
+    - name: Create scale-ci-deploy directories
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin"
+        - "{{ ansible_user_dir }}/.docker"
+
+    - name: Set kubeconfig path
+      set_fact:
+        kubeconfig_path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/auth/kubeconfig"
   roles:
     - role: openshift-cleanup
       when: openshift_cleanup|bool

--- a/OCP-4.X/install-on-osp.yml
+++ b/OCP-4.X/install-on-osp.yml
@@ -12,6 +12,27 @@
     - vars/install-on-osp.yml
   vars:
     platform: "osp"
+  pre_tasks:
+
+    - name: Include platform variables
+      include_vars:
+        file: "vars/install-on-{{ platform }}.yml"
+
+    - name: Set dynamic scale-ci-deploy path
+      set_fact:
+        dynamic_deploy_path: "{% if lookup('env', 'DYNAMIC_DEPLOY_PATH') %}{{ lookup('env', 'DYNAMIC_DEPLOY_PATH') }}{% else %}scale-ci-{{ openshift_cluster_name }}-{{ platform }}{% endif %}"
+
+    - name: Create scale-ci-deploy directories
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin"
+        - "{{ ansible_user_dir }}/.docker"
+
+    - name: Set kubeconfig path
+      set_fact:
+        kubeconfig_path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/auth/kubeconfig"
   roles:
     - role: install-on-osp
       when: openshift_install|bool

--- a/OCP-4.X/roles/cerberus_install/tasks/main.yml
+++ b/OCP-4.X/roles/cerberus_install/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Get scale-ci-deploy directory
-  set_fact:
-    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
-
 - name: Generate cerberus config file
   template:
     src: cerberus.j2
@@ -29,11 +25,11 @@
   loop: "{{ cerberus_containers.stdout_lines }}"
 
 - name: Run containerized version of "{{ cerberus_image }}"
-  command: podman run --name=cerberus-{{ openshift_cluster_name }}-{{ platform }} --net=host -v "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/auth/kubeconfig":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z -d "{{ cerberus_image }}"
+  command: podman run --name=cerberus-{{ openshift_cluster_name }}-{{ platform }} --net=host -v "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/auth/kubeconfig":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z -d "{{ cerberus_image }}"
   when: not slack_integration | bool
 
 - name: Run containerized version of "{{ cerberus_image }}" with slack integration
-  command: podman run --name=cerberus-{{ openshift_cluster_name }}-{{ platform }} --net=host -v "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/auth/kubeconfig":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z --env SLACK_API_TOKEN="{{ slack_api_token }}" --env SLACK_CHANNEL="{{ slack_channel }}" -d "{{ cerberus_image }}"
+  command: podman run --name=cerberus-{{ openshift_cluster_name }}-{{ platform }} --net=host -v "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/auth/kubeconfig":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z --env SLACK_API_TOKEN="{{ slack_api_token }}" --env SLACK_CHANNEL="{{ slack_channel }}" -d "{{ cerberus_image }}"
   when: slack_integration | bool
 
 - name: Pause for cerberus to finish the first iteration after which it exposes the go/no-go signal

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -9,28 +9,16 @@
 # * Install cluster
 #
 
-- name: Get scale-ci-deploy directory
-  set_fact:
-    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
-
-- name: Create {{ scale_ci_deploy_directory }} directories
-  file:
-    path: "{{item}}"
-    state: directory
-  with_items:
-    - "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin"
-    - "{{ ansible_user_dir }}/.docker"
-
 - name: Download oc client tools
   get_url:
     url: "{{openshift_client_location}}"
-    dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin/{{openshift_client_location | basename}}"
+    dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin/{{openshift_client_location | basename}}"
 
 - name: Untar and install oc client tools
   become: true
   shell: |
     set -o pipefail
-    cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin
+    cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin
     tar xzf {{ openshift_client_location | basename }}
     cp oc /usr/local/bin/oc
     cp kubectl /usr/local/bin/kubectl
@@ -43,7 +31,7 @@
 - name: Extract openshift-install binary from the payload
   shell: |
     set -o pipefail
-    cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin
+    cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin
     oc adm release extract --tools {{openshift_install_release_image_override}}
     ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
     chmod +x openshift-install
@@ -94,23 +82,23 @@
 - name: Create clouds.yml
   template:
     src: clouds.yml.j2
-    dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/clouds.yml"
+    dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/clouds.yml"
 
 - name: Download image
   get_url:
     url: "{{openshift_image_location}}"
-    dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/{{openshift_image_location | basename}}"
+    dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/{{openshift_image_location | basename}}"
   when: openstack_upload_image|bool
 
 - name: Converting qcow2 image to raw format
   shell: |
-    qemu-img convert -f qcow2 -O raw {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/{{ (openshift_image_location | basename | splitext)[0] }}.raw
+    qemu-img convert -f qcow2 -O raw {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/{{ (openshift_image_location | basename | splitext)[0] }}.raw
   when: openstack_upload_image|bool
 
 - name: Upload image into glance
   shell: |
     . {{ ansible_user_dir }}/overcloudrc
-    openstack image create --disk-format raw --container-format bare --file {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/{{ (openshift_image_location | basename | splitext)[0] }}.raw rhcos --format value -c id
+    openstack image create --disk-format raw --container-format bare --file {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/{{ (openshift_image_location | basename | splitext)[0] }}.raw rhcos --format value -c id
   register: glance_image_id
   when: openstack_upload_image|bool
 
@@ -180,18 +168,18 @@
     src: install-config.yaml.j2
     dest: "{{item}}"
   with_items:
-    - "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/install-config.yaml"
+    - "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/install-config.yaml"
 
 - block:
    - name: Fetch the openshift-install binary tarball
      get_url:
        url: "{{ openshift_install_binary_url }}"
-       dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin/"
+       dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin/"
 
    - name: Extract openshift-install binary
      shell: |
        set -o pipefail
-       cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/bin
+       cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin
        ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
        chmod +x openshift-install
   when: openshift_install_binary_url != ""
@@ -199,10 +187,10 @@
 - name: Run openshift-install on OSP using the image override
   shell: |
     set -o pipefail
-    cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}
+    cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
-    export OS_CLIENT_CONFIG_FILE={{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/clouds.yml
+    export OS_CLIENT_CONFIG_FILE={{ ansible_user_dir }}/{{ dynamic_deploy_path }}/clouds.yml
     bin/openshift-install create cluster --log-level=debug
 
 - name: Create dir to store artifacts
@@ -213,7 +201,7 @@
 
 - name: Copy the install log to the artifacts dir
   fetch:
-    src: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/.openshift_install.log"
+    src: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/.openshift_install.log"
     dest: "{{ playbook_dir }}/{{ dynamic_deploy_path }}-artifacts/openshift_install.log"
     flat: yes
 

--- a/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
@@ -3,24 +3,20 @@
 # Clean up cluster
 #
 
-- name: Get scale-ci-deploy directory
-  set_fact:
-    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
-
 - name: Check if a cluster is running
   stat:
-    path: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/metadata.json"
+    path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/metadata.json"
   register: cluster_status
 
 - block:
     - name: Cleanup cluster
       shell: |
-        cd {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/
+        cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/
         export GOOGLE_CREDENTIALS={{ gcp_auth_key_file|default() }}
         bin/openshift-install destroy cluster --log-level=debug
 
     - name: Clean scale-ci-deploy openshift-install directories
       file:
-        path: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}"
+        path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}"
         state: absent
   when: cluster_status.stat.exists == True

--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -9,22 +9,6 @@
 # * Install cluster
 #
 
-- name: Create dynamic scale-ci-deploy path
-  set_fact:
-    dynamic_deploy_path: "scale-ci-{{ openshift_cluster_name }}-{{ platform }}"
-
-- name: Set kubeconfig path
-  set_fact:
-    kubeconfig_path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/auth/kubeconfig"
-
-- name: Create scale-ci-deploy directories
-  file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin"
-    - "{{ ansible_user_dir }}/.docker"
-
 - name: Download oc client tools
   get_url:
     url: "{{ openshift_client_location }}"

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -8,10 +8,6 @@
 #  * Moves infra node pods/workload to infra nodes
 #
 
-- name: Get scale-ci-deploy directory
-  set_fact:
-    scale_ci_deploy_directory: "{{ dynamic_deploy_path|default(lookup('env', 'dynamic_deploy_path')) | default('scale-ci-deploy', true) }}"
-
 - name: Get cluster name
   shell: |
     {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index (index .items 0).metadata.labels {%endraw%} "{{ machineset_metadata_label_prefix }}/cluster-api-cluster" {%raw%})}}'{%endraw%}
@@ -35,7 +31,7 @@
     cmd: index-install-data.sh
   environment:
     ES_SERVER: "{{ es_server }}"
-    INSTALL_LOG: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/.openshift_install.log"
+    INSTALL_LOG: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/.openshift_install.log"
 
 - name: Get current ready node count
   shell: oc get nodes | grep " Ready" -ic
@@ -66,10 +62,10 @@
       when: item.toggle|bool
       with_items:
         - src: aws-infra-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/infra-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/infra-node-machineset.yml"
           toggle: "{{openshift_toggle_infra_node}}"
         - src: aws-workload-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/workload-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
           toggle: "{{openshift_toggle_workload_node}}"
   when: platform == "aws"
 
@@ -96,10 +92,10 @@
       when: item.toggle|bool
       with_items:
         - src: azure-infra-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/infra-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/infra-node-machineset.yml"
           toggle: "{{openshift_toggle_infra_node}}"
         - src: azure-workload-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/workload-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
           toggle: "{{openshift_toggle_workload_node}}"
   when: platform == "azure"
 
@@ -112,20 +108,20 @@
       when: item.toggle|bool
       with_items:
         - src: gcp-infra-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/infra-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/infra-node-machineset.yml"
           toggle: "{{openshift_toggle_infra_node}}"
         - src: gcp-workload-node-machineset.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/workload-node-machineset.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
           toggle: "{{openshift_toggle_workload_node}}"
         - src: gcp-ssd-sc.yml.j2
-          dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/pd-ssd-sc.yml"
+          dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/pd-ssd-sc.yml"
           toggle: true
 
     - name: (GCP) Create faster ssd sc
       shell: |
         oc create -f {{ item.sc }}
       with_items:
-        - sc: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/pd-ssd-sc.yml"
+        - sc: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/pd-ssd-sc.yml"
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
 
@@ -137,10 +133,10 @@
     dest: "{{item.dest}}"
   with_items:
     - src: osp-infra-node-machineset.yml.j2
-      dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/infra-node-machineset.yml"
+      dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/infra-node-machineset.yml"
       toggle: "{{openshift_toggle_infra_node}}"
     - src: osp-workload-node-machineset.yml.j2
-      dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/workload-node-machineset.yml"
+      dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
       toggle: "{{openshift_toggle_workload_node}}"
   when:
     - item.toggle|bool
@@ -150,9 +146,9 @@
   shell: |
     oc create -f {{item.ms}}
   with_items:
-    - ms: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/infra-node-machineset.yml"
+    - ms: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/infra-node-machineset.yml"
       toggle: "{{openshift_toggle_infra_node}}"
-    - ms: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/workload-node-machineset.yml"
+    - ms: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
       toggle: "{{openshift_toggle_workload_node}}"
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
@@ -217,12 +213,12 @@
 - name: Copy new cluster-monitoring-config
   template:
     src: cluster-monitoring-config.yml.j2
-    dest: "{{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/cluster-monitoring-config.yml"
+    dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml"
   when: openshift_toggle_infra_node|bool
 
 - name: Replace the cluster-monitoring-config ConfigMap
   shell: |
-    oc create -f {{ ansible_user_dir }}/{{ scale_ci_deploy_directory }}/cluster-monitoring-config.yml
+    oc create -f {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml
   ignore_errors: yes
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"


### PR DESCRIPTION
Replace scale_ci_deploy_directory with dynamic_deploy_path.
Now dynamic_deploy_path is set in an Ansible pre-task (before executing any role).

The expression to set dynamic_deploy_path has been updated to:

```yaml
    - name: Set dynamic scale-ci-deploy path
      set_fact:
        dynamic_deploy_path: "{% if lookup('env', 'DYNAMIC_DEPLOY_PATH') %}{{ lookup('env', 'DYNAMIC_DEPLOY_PATH') }}{% else %}scale-ci-{{ openshift_cluster_name }}-{{ platform }}{% endif %}"
```

Wich will use DYNAMIC_DEPLOY_PATH env var value if set or `scale-ci-{{ openshift_cluster_name }}-{{ platform }}{`

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>