### PR TITLE
Cleanup bin

### DIFF
--- a/OCP-4.X/clean-on-osp.yml
+++ b/OCP-4.X/clean-on-osp.yml
@@ -57,14 +57,17 @@
       ignore_errors: true
       when: delete_image|bool
 
+    - name: Get contents from bin directory
+      find:
+        paths: "{{ ansible_user_dir }}/scale-ci-deploy/bin"
+      register: bin_content
+
     - name: Clean scale-ci-deploy openshift-install directories
       become: true
       file:
-        path: "{{item}}"
+        path: "{{ item.path }}"
         state: absent
-      with_items:
-        - "{{ ansible_user_dir }}/scale-ci-deploy/bin"
-        - "{{ ansible_user_dir }}/scale-ci-deploy/scale-ci-openstack"
+      with_items: "{{ bin_content }}"
 
     - name: Remove old entries from /etc/hosts
       become: true

--- a/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
@@ -15,8 +15,15 @@
         export GOOGLE_CREDENTIALS={{ gcp_auth_key_file|default() }}
         bin/openshift-install destroy cluster --log-level=debug
 
+    - name: Get contents from bin directory
+      find:
+        paths: "{{ ansible_user_dir }}/scale-ci-deploy/bin"
+      register: bin_content
+
     - name: Clean scale-ci-deploy openshift-install directories
       file:
-        path: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}"
+        path: "{{ item.path }}"
         state: absent
+      with_items: "{{ bin_content }}"
+
   when: cluster_status.stat.exists == True


### PR DESCRIPTION
# Description

Cleanup contents from bin directory only

Fixes # (issue)

Will prevent scale-ci-deploy to hang when cleanup is executed (bin directory was deleted so it cant extract install binaries in there)
