### PR TITLE
Use dynamic_deploy_path to cleanup bin directory

### DIFF
--- a/OCP-4.X/clean-on-osp.yml
+++ b/OCP-4.X/clean-on-osp.yml
@@ -59,7 +59,7 @@
 
     - name: Get contents from bin directory
       find:
-        paths: "{{ ansible_user_dir }}/scale-ci-deploy/bin"
+        paths: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin"
       register: bin_content
 
     - name: Clean scale-ci-deploy openshift-install directories

--- a/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
@@ -17,7 +17,7 @@
 
     - name: Get contents from bin directory
       find:
-        paths: "{{ ansible_user_dir }}/scale-ci-deploy/bin"
+        paths: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin"
       register: bin_content
 
     - name: Clean scale-ci-deploy openshift-install directories


### PR DESCRIPTION
We need to use dynamic_deploy_path to actually remove the bin directory

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>