### PR TITLE
add worker node machineset image to infra and workload node

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -101,6 +101,20 @@
 
 - name: GCP block of tasks
   block:
+    - name: Get machineset name of a worker node
+      shell: |
+        {%raw%}oc get machinesets --no-headers -n openshift-machine-api | awk {'print $1'} | awk 'NR==1{print $1}'{%endraw%}
+      register: worker_node_machineset
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+
+    - name: Get machineset image from worker node
+      shell: |
+       oc get machineset {{ worker_node_machineset.stdout }} -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}'
+      register: worker_machineset_image
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+
     - name: (GCP) Template out machineset yamls
       template:
         src: "{{item.src}}"

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -40,7 +40,7 @@ items:
             disks:
             - autoDelete: false
               boot: true
-              image: {{cluster_name.stdout}}-rhcos-image
+              image: {{worker_machineset_image.stdout}}
               labels: null
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}
@@ -104,7 +104,7 @@ items:
             disks:
             - autoDelete: false
               boot: true
-              image: {{cluster_name.stdout}}-rhcos-image
+              image: {{worker_machineset_image.stdout}}
               labels: null
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}
@@ -168,7 +168,7 @@ items:
             disks:
             - autoDelete: false
               boot: true
-              image: {{cluster_name.stdout}}-rhcos-image
+              image: {{worker_machineset_image.stdout}}
               labels: null
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -38,7 +38,7 @@ spec:
           disks:
           - autoDelete: false
             boot: true
-            image: {{cluster_name.stdout}}-rhcos-image
+            image: {{worker_machineset_image.stdout}}
             labels: null
             sizeGb: {{openshift_workload_node_volume_size}}
             type: {{openshift_workload_node_volume_type}}


### PR DESCRIPTION
# Description
The current implementation doesn't get us infra and workload node as the image is not available.
This commit copies the image from worker machineset
