### PR TITLE
removing cluster-name from machineset names

### DIFF
--- a/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
@@ -15,7 +15,7 @@ items:
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}a
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}a
       spec:
         metadata:
           creationTimestamp: null
@@ -86,7 +86,7 @@ items:
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}b
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}b
     template:
       metadata:
         creationTimestamp: null
@@ -94,7 +94,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}b
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}b
       spec:
         metadata:
           creationTimestamp: null
@@ -157,7 +157,7 @@ items:
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}c
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}c
     template:
       metadata:
         creationTimestamp: null
@@ -165,7 +165,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{aws_region.stdout}}c
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}c
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
@@ -8,14 +8,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-    name: {{cluster_name.stdout}}-workload-{{aws_region.stdout}}d
+    name: workload-{{aws_region.stdout}}d
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-{{aws_region.stdout}}d
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}d
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-{{aws_region.stdout}}d
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}d
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
@@ -8,14 +8,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}1
+    name: infra-{{azure_location.stdout}}1
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}1
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}1
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}1
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}1
       spec:
         metadata:
           creationTimestamp: null
@@ -75,14 +75,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}2
+    name: infra-{{azure_location.stdout}}2
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}2
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}2
     template:
       metadata:
         creationTimestamp: null
@@ -90,7 +90,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}2
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}2
       spec:
         metadata:
           creationTimestamp: null
@@ -142,14 +142,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}3
+    name: infra-{{azure_location.stdout}}3
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}3
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}3
     template:
       metadata:
         creationTimestamp: null
@@ -157,7 +157,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-{{azure_location.stdout}}3
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}3
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/azure-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-workload-node-machineset.yml.j2
@@ -8,14 +8,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-    name: {{cluster_name.stdout}}-workload-{{azure_location.stdout}}1
+    name: workload-{{azure_location.stdout}}1
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-{{azure_location.stdout}}1
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{azure_location.stdout}}1
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-{{azure_location.stdout}}1
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{azure_location.stdout}}1
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -6,9 +6,8 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: {{cluster_name.stdout}}-infra-a
+    name: infra-a
     namespace: openshift-machine-api
-    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-a
   spec:
     replicas: 1
     selector:
@@ -16,7 +15,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-a
     template:
       metadata:
         creationTimestamp: null
@@ -24,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-a
       spec:
         metadata:
           creationTimestamp: null
@@ -70,9 +69,8 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: {{cluster_name.stdout}}-infra-b
+    name: infra-b
     namespace: openshift-machine-api
-    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-b
   spec:
     replicas: 1
     selector:
@@ -80,7 +78,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-b
     template:
       metadata:
         creationTimestamp: null
@@ -88,7 +86,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-b
       spec:
         metadata:
           creationTimestamp: null
@@ -134,9 +132,9 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: {{cluster_name.stdout}}-infra-c
+    name: infra-c
     namespace: openshift-machine-api
-    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-c
+    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/infra-c
   spec:
     replicas: 1
     selector:
@@ -144,7 +142,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-c
     template:
       metadata:
         creationTimestamp: null
@@ -152,7 +150,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-c
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -134,7 +134,6 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
     name: infra-c
     namespace: openshift-machine-api
-    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/infra-c
   spec:
     replicas: 1
     selector:

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -4,9 +4,9 @@ metadata:
   generation: 1
   labels:
     {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-  name: {{cluster_name.stdout}}-workload-a
+  name: workload-a
   namespace: openshift-machine-api
-  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-workload-a
+  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/workload-a
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-      {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
+      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-a
   template:
     metadata:
       creationTimestamp: null
@@ -22,7 +22,7 @@ spec:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-a
     spec:
       metadata:
         creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
@@ -8,14 +8,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: {{cluster_name.stdout}}-infra
+    name: infra
     namespace: openshift-machine-api
   spec:
     replicas: 3
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/osp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-workload-node-machineset.yml.j2
@@ -8,14 +8,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-    name: {{cluster_name.stdout}}-workload
+    name: workload
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload
       spec:
         metadata:
           creationTimestamp: null


### PR DESCRIPTION
### Description

The infra/workload machinesets we create currently have the format of $CLUSTER_NAME-$MACHINESET_NAME which can cause issues for underlying machines if the cluster name is long enough. Since the machinesets/machines get labeled with the cluster name there's not a great reason to prepend the name to the resources (the aws infra machinesets already don't do it) 
