### PR TITLE
Retry mechanism for oc client tools 

### DIFF
--- a/CI/run_ci.sh
+++ b/CI/run_ci.sh
@@ -45,7 +45,7 @@ for test in ${test_list[@]}; do
   echo "${ORCHESTRATION_HOST}" >> inventory
 
   export ANSIBLE_FORCE_COLOR=true 
-  ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=${test} 
+  #ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=${test} 
 
   EXIT_STATUS=$?
   if [ "$EXIT_STATUS" -eq "0" ]                                    #to check if the test exits successfully or not

--- a/CI/run_ci.sh
+++ b/CI/run_ci.sh
@@ -45,7 +45,7 @@ for test in ${test_list[@]}; do
   echo "${ORCHESTRATION_HOST}" >> inventory
 
   export ANSIBLE_FORCE_COLOR=true 
-  #ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=${test} 
+  ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=${test} 
 
   EXIT_STATUS=$?
   if [ "$EXIT_STATUS" -eq "0" ]                                    #to check if the test exits successfully or not

--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -9,6 +9,22 @@
 # * Install cluster
 #
 
+- name: Check for oc client tools install payload
+  shell: |
+    echo {{ openshift_client_location }} | sed -e 's/\(.*\)openshift-client.*/\1/'
+  register: CLIENT_BASE_URL
+
+- name: Pause play until CLIENT URL is reachable
+  uri:
+    url: "{{ CLIENT_BASE_URL.stdout }}"
+    follow_redirects: none
+    method: GET
+  register: _result
+  until: _result.status == 200
+  retries: 60
+  delay: 5
+
+
 - name: Download oc client tools
   get_url:
     url: "{{ openshift_client_location }}"


### PR DESCRIPTION
### Description
The retry mechanism is required for oc client tools as well , since the mirror.openshift.com hosting the openshift-client has the same optimization technique as for the binary tarball  


