### PR TITLE
Refactor deploy docs to match usage in README

### DIFF
--- a/docs/aws-example.sh
+++ b/docs/aws-example.sh
@@ -81,7 +81,7 @@ set -eux
 echo "[orchestration]" > inventory
 echo "${ORCHESTRATION_HOST}" >> inventory
 
-ansible-playbook -vv -i inventory OCP-4.X/install-on-aws.yml
+ansible-playbook -vv -i inventory -e OCP-4.X/deploy-cluster.yml -e platform=aws
 
 ####################################################################################################
 # Post Jenkins Build Clean up:

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI AWS Install Documentation
 
-The OpenShift 4 IPI AWS variable file is `OCP-4.X/vars/install-on-aws.yml` and will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on AWS. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI AWS variable file can be found at `OCP-4.X/vars/install-on-aws.yml`. It will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on AWS. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your expected orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-aws.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster -e platform=aws
+$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=aws
 ```
 
 ## Example

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI AWS Install Documentation
 
-The OpenShift 4 IPI AWS install playbook is `OCP-4.X/install-on-aws.yml` and will deploy a cluster on AWS. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI AWS variable file is `OCP-4.X/vars/install-on-aws.yml` and will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on AWS. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your expected orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-aws.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/install-on-aws.yml
+$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster -e platform=aws
 ```
 
 ## Example

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI Azure Install Documentation
 
-The OpenShift 4 IPI Azure install playbook is `OCP-4.X/install-on-azure.yml` and will deploy a cluster on Azure. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI Azure variable file can be found at `OCP-4.X/install-on-azure.yml`. It will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on Azure. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your expected orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-azure.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/install-on-azure.yml
+$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster -e platform=azure
 ```
 
 ## Environment variables

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI GCP Install Documentation
 
-The OpenShift 4 IPI GCP install playbook is `OCP-4.X/install-on-gcp.yml` and will deploy a cluster on GCP. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI GCP variable file can be found at `OCP-4.X/vars/install-on-gcp.yml`. It will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on GCP. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your expected orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-gcp.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/install-on-gcp.yml
+$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=gcp
 ```
 
 ## Environment variables

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI OpenStack Install Documentation
 
-The OpenShift 4 IPI OpenStack install playbook is `OCP-4.X/install-on-osp.yml` and will deploy a cluster on OpenStack. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI OpenStack variable file can be found at `OCP-4.X/vars/install-on-osp.yml`. It will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on OpenStack. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 The OpenStack cloud in which this has been tested with and on is a Red Hat OpenStack Platform 13 cloud installed via tripleo. The install orchestration used to deploy the cloud is [openshift-scale/scale-ci-tripleo](https://github.com/openshift-scale/scale-ci-tripleo).
 
@@ -12,7 +12,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your undercloud machine as the orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-osp.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/install-on-osp.yml
+$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=osp
 ```
 
 Note that for Tripleo OpenStack Clouds, the Undercloud machine is used as the orchestration host as it will be easier to setup/coordinate any sort of lab specific networking on this machine (Usually).

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -1,6 +1,6 @@
 # OpenShift 4 IPI OpenStack Install Documentation
 
-The OpenShift 4 IPI OpenStack variable file can be found at `OCP-4.X/vars/install-on-osp.yml`. It will configure the deployment playbook at `OCP-4.X/deploy-cluster.yml` to perform a cluster installation on OpenStack. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+The OpenShift 4 IPI OpenStack install playbook is `OCP-4.X/install-on-osp.yml` and will deploy a cluster on OpenStack. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
 
 The OpenStack cloud in which this has been tested with and on is a Red Hat OpenStack Platform 13 cloud installed via tripleo. The install orchestration used to deploy the cloud is [openshift-scale/scale-ci-tripleo](https://github.com/openshift-scale/scale-ci-tripleo).
 

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -12,7 +12,7 @@ Running from the CLI:
 $ cp OCP-4.X/inventory.example inventory
 $ # Edit inventory and add your undercloud machine as the orchestration host
 $ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-osp.yml) or define env variables
-$ ansible-playbook -v -i inventory OCP-4.X/deploy-cluster.yml -e platform=osp
+$ ansible-playbook -v -i inventory OCP-4.X/install-on-osp.yml
 ```
 
 Note that for Tripleo OpenStack Clouds, the Undercloud machine is used as the orchestration host as it will be easier to setup/coordinate any sort of lab specific networking on this machine (Usually).


### PR DESCRIPTION
### Description

Usage given in docs does not match the usage in the README. Docs specify running a distinct playbook per cloud provider, rather than configuring a var file and given a ``platform`` env variable. 

### Fixes

Documentation to match usage under README.