### PR TITLE
Add task to ensure .aws directory exists before writing config

### DIFF
--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: Use installer from a build
   block:
-  
+
   - name: Extract openshift-install binary from the payload
     shell: |
       set -eo pipefail
@@ -133,11 +133,16 @@
 - name: Setting up AWS
   block:
 
+  - name: Create .aws dir
+    file:
+      path: "{{ ansible_user_dir }}/.aws"
+      state: directory
+
   - name: AWS config
     template:
        src: config.j2
        dest: "{{ ansible_user_dir }}/.aws/config"
-  
+
   - name: AWS credentials
     template:
        src: credentials.j2
@@ -225,7 +230,7 @@
        cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin/
        ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
        chmod +x openshift-install
-       
+
   when: openshift_install_binary_url != ""
 
 - name: Setup install-config.yaml


### PR DESCRIPTION
### Description

Deploy playbook will fail on AWS with a message like ``Destination directory /root/.aws does not exist`` if the AWS configuration is not setup for the root user ahead of time.

### Fixes

Adds a task to create a ``.aws`` directory under the ``ansible_user_dir``. This is similar method for Azure config, as there exists a task in this file for creating ``.azure`` before writing the client config. 