### PR TITLE
Replace "root" with "{{orchestration_user}}" to match deploy-cluster.yml

### DIFF
--- a/OCP-4.X/destroy-cluster.yml
+++ b/OCP-4.X/destroy-cluster.yml
@@ -5,7 +5,7 @@
   hosts: orchestration
   gather_facts: true
   become: true
-  remote_user: root
+  remote_user: "{{orchestration_user}}"
   vars_files:
     - vars/install-common-vars.yml
   pre_tasks:


### PR DESCRIPTION
### Description

Cases can occur where ``destroy-cluster.yml`` can fail if using an orchestration host that requires login as non-root and then
escalation.

### Fixes

Sets user to ``{{orchestration_user}}``, as is found in [deploy-cluster.yml](https://github.com/cloud-bulldozer/scale-ci-deploy/blob/master/OCP-4.X/deploy-cluster.yml), to allow for login as non-root and then escalation to root.