### PR TITLE
Adding AZ param to workload node machineset for aws

### DIFF
--- a/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
@@ -15,7 +15,7 @@ items:
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}d
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}{{ workload_aws_az_suffix | default('d') }}
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}d
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{aws_region.stdout}}{{ workload_aws_az_suffix | default('d') }}
       spec:
         metadata:
           creationTimestamp: null
@@ -49,7 +49,7 @@ items:
             metadata:
               creationTimestamp: null
             placement:
-              availabilityZone: {{aws_region.stdout}}d
+              availabilityZone: {{aws_region.stdout}}{{ workload_aws_az_suffix | default('d') }}
               region: {{aws_region.stdout}}
             publicIp: true
             securityGroups:

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -4,6 +4,7 @@ aws_profile: "{{ lookup('env', 'AWS_PROFILE')|default('default', true) }}"
 aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
 aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
 aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+workload_aws_az_suffix: "{{ lookup('env', 'WORKLOAD_AWS_AZ_SUFFIX') }}"
 
 # Cluster configuration
 openshift_base_domain: "{{ lookup('env', 'OPENSHIFT_BASE_DOMAIN') }}"

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -150,3 +150,8 @@ The storage class for the alertmanager servers.
 
 ### OPENSHIFT_ALERTMANAGER_STORAGE_SIZE
 Default: `2Gi`
+
+### WORKLOAD_AWS_AZ_SUFFIX
+Default: `d`
+Default EC2 availability zone(AZ) is set to `d`, but some regions do not have the AZ `d`, in that case you can set this to some other letter.
+E.g. for `us-east-2`, you can request `us-east-2a/b/c` as `us-east-2d` does not exist.


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description

Making Scale ci deploy accept a `workload_aws_az_suffix` variable to allow specifying what suffix to use for az. It can accept single letter value e.g. `a`,`b`,`c` etc. Applies only to workload node machineset.

### Fixes

This fixes the issue where scale-ci-deploy is assuming that workload nodes should be in a different AZ - but not all regions have an AZ `d`. E.g. `us-east-2d` doesn't exist.
