### PR TITLE
ACS: Handle repeat runs

### DIFF
--- a/OCP-4.X/roles/rhacs_install/tasks/main.yml
+++ b/OCP-4.X/roles/rhacs_install/tasks/main.yml
@@ -50,6 +50,7 @@
 
 - name: Get secure cluster bundle
   shell: |
+    rm -f perf-bundle.yml
     roxctl -e https://{{ central_route.stdout }}:443 -p "{{ central_pass }}" central init-bundles generate {{ cluster_name }} \
       --output perf-bundle.yml
   environment:

--- a/OCP-4.X/roles/rhacs_install/tasks/main.yml
+++ b/OCP-4.X/roles/rhacs_install/tasks/main.yml
@@ -48,9 +48,13 @@
     dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin/"
     mode: 0755
 
+- name: Cleanup previous run
+  file:
+    path: perf-bundle.yml
+    state: absent
+
 - name: Get secure cluster bundle
   shell: |
-    rm -f perf-bundle.yml
     roxctl -e https://{{ central_route.stdout }}:443 -p "{{ central_pass }}" central init-bundles generate {{ cluster_name }} \
       --output perf-bundle.yml
   environment:


### PR DESCRIPTION
### Description

When ACS deploy happens from the same jump host where it ran before it fails due to the previous install bundle file.

### Fixes

Remove the bundle file prior to deploy.