### PR TITLE
Thanos Support

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -22,6 +22,13 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
+- name: Get cluster release stream
+  command: |
+    {%raw%}oc get clusterversion version -o go-template --template="{{.spec.channel}}"{%endraw%}
+  register: ocp_release_stream
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+
 - name: Set userDataSecret name
   set_fact:
     user_data_secret: "worker-user-data"

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -22,13 +22,6 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
-- name: Get cluster release stream
-  command: |
-    {%raw%}oc get clusterversion version -o go-template --template="{{.spec.channel}}"{%endraw%}
-  register: ocp_release_stream
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-
 - name: Set userDataSecret name
   set_fact:
     user_data_secret: "worker-user-data"

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -11,6 +11,10 @@ data:
     prometheusK8s:
       externalLabels:
         openshift_cluster_name: {{cluster_name.stdout}}
+        openshift_network_type: {{openshift_network_type}}
+        openshift_version: {{ocp_version.stdout}}
+        openshift_platform: {{platform}}
+        openshift_release_stream: {{ocp_release_stream.stdout}}
       remoteWrite:
         - url: http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive
       retention: {{openshift_prometheus_retention_period}}

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -14,7 +14,6 @@ data:
         openshift_network_type: {{openshift_network_type}}
         openshift_version: {{ocp_version.stdout}}
         openshift_platform: {{platform}}
-        openshift_release_stream: {{ocp_release_stream.stdout}}
       remoteWrite:
         - url: http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive
       retention: {{openshift_prometheus_retention_period}}

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -9,6 +9,10 @@ data:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
     prometheusK8s:
+      externalLabels:
+        openshift_cluster_name: {{cluster_name.stdout}}
+      remoteWrite:
+        - url: http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus
       nodeSelector:

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -18,8 +18,8 @@ data:
       remoteWrite:
         - url: {{ thanos_receiver_url }}
           write_relabel_configs:
-          - source_labels: [pod, name, namespace]
-            regex: ".*cluster-density.*|.*node-density.*|.*perfapp.*"
+          - source_labels: [prometheus_replica]
+            regex: "prometheus-k8s-1"
             action: drop
 {% endif %}
       retention: {{openshift_prometheus_retention_period}}

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -18,8 +18,8 @@ data:
       remoteWrite:
         - url: {{ thanos_receiver_url }}
           write_relabel_configs:
-          - source_labels: [prometheus_replica]
-            regex: "prometheus-k8s-1"
+          - source_labels: [pod, name, namespace]
+            regex: ".*cluster-density.*|.*node-density.*|.*perfapp.*"
             action: drop
 {% endif %}
       retention: {{openshift_prometheus_retention_period}}

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -9,7 +9,7 @@ data:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
     prometheusK8s:
-{%- if thanos_enable and thanos_receiver_url != "" %}
+{% if thanos_enable %}
       externalLabels:
         openshift_cluster_name: {{ cluster_name.stdout }}
         openshift_network_type: {{ openshift_network_type }}
@@ -17,7 +17,7 @@ data:
         openshift_platform: {{ platform }}
       remoteWrite:
         - url: {{ thanos_receiver_url }}
-{%- endif %}
+{% endif %}
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus
       nodeSelector:

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -9,13 +9,15 @@ data:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
     prometheusK8s:
+{%- if thanos_enable and thanos_receiver_url != "" %}
       externalLabels:
-        openshift_cluster_name: {{cluster_name.stdout}}
-        openshift_network_type: {{openshift_network_type}}
-        openshift_version: {{ocp_version.stdout}}
-        openshift_platform: {{platform}}
+        openshift_cluster_name: {{ cluster_name.stdout }}
+        openshift_network_type: {{ openshift_network_type }}
+        openshift_version: {{ ocp_version.stdout }}
+        openshift_platform: {{ platform }}
       remoteWrite:
-        - url: http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive
+        - url: {{ thanos_receiver_url }}
+{%- endif %}
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus
       nodeSelector:

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -17,10 +17,6 @@ data:
         openshift_platform: {{ platform }}
       remoteWrite:
         - url: {{ thanos_receiver_url }}
-          write_relabel_configs:
-          - source_labels: [pod, name, namespace]
-            regex: ".*cluster-density.*|.*node-density.*|.*perfapp.*"
-            action: drop
 {% endif %}
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -17,6 +17,10 @@ data:
         openshift_platform: {{ platform }}
       remoteWrite:
         - url: {{ thanos_receiver_url }}
+          write_relabel_configs:
+          - source_labels: [pod, name, namespace]
+            regex: "cluster-density|node-density|perfapp"
+            action: drop
 {% endif %}
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -19,7 +19,7 @@ data:
         - url: {{ thanos_receiver_url }}
           write_relabel_configs:
           - source_labels: [pod, name, namespace]
-            regex: "cluster-density|node-density|perfapp"
+            regex: ".*cluster-density.*|.*node-density.*|.*perfapp.*"
             action: drop
 {% endif %}
       retention: {{openshift_prometheus_retention_period}}

--- a/OCP-4.X/vars/install-common-vars.yml
+++ b/OCP-4.X/vars/install-common-vars.yml
@@ -122,3 +122,9 @@ openshift_ovn_image: "{{ lookup('env', 'OVN_IMAGE')|default('', true) }}"
 
 # RHACS
 rhacs_enable: "{{ lookup('env', 'RHACS_ENABLE')|default(false, true) }}"
+
+
+# Thanos
+thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"
+thanos_receiver_url: "{{ lookup('env', 'THANOS_RECEIVER_URL')|default('http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive', true) }}"
+

--- a/docs/ocp4_common_env_var.md
+++ b/docs/ocp4_common_env_var.md
@@ -280,3 +280,10 @@ Password for the first super user.
 ### POSTGRES_PASSWORD
 Default: No default.
 Postgresql database super user password.
+
+### THANOS_ENABLE
+Default: False
+Turn on remote_write to a thanos instance
+
+### THANOS_RECEIVER_URL
+URL for the receiver to remote_write to. 


### PR DESCRIPTION
Adds the ability to remote_write to a thanos receiver with appropriate external labels. 

Dag running with these changes here: http://whitleykeith-thanos-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?dag_id=4.8_aws_default&task_id=install&execution_date=2021-07-28T15%3A42%3A44.940964%2B00%3A00