### PR TITLE
ACS: allow the main image source to be specified

### DIFF
--- a/OCP-4.X/roles/rhacs_install/tasks/main.yml
+++ b/OCP-4.X/roles/rhacs_install/tasks/main.yml
@@ -19,7 +19,11 @@
   shell: |
     helm install -n stackrox \
       --create-namespace stackrox-central-services rhacs/central-services \
-      --set imagePullSecrets.allowNone=true \
+      --set imagePullSecrets.allowNone={{ (rhacs_image_pull_secret_username == "") }} \
+      {{  (rhacs_image_pull_secret_username == "" ) | ternary("", "--set imagePullSecrets.username=" + rhacs_image_pull_secret_username) }} \
+      {{  (rhacs_image_pull_secret_password == "" ) | ternary("", "--set imagePullSecrets.password=" + rhacs_image_pull_secret_password) }} \
+      {{  (rhacs_image_main_registry == "" )        | ternary("", "--set central.image.registry=" + rhacs_image_main_registry) }} \
+      {{  (rhacs_image_main_tag == "" )             | ternary("", "--set central.image.tag=" + rhacs_image_main_tag) }} \
       --set central.exposure.route.enabled=true \
       --set central.adminPassword.value={{ central_pass }} \
       --set central.exposeMonitoring=true
@@ -65,7 +69,11 @@
     helm install -n stackrox \
       --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services \
       -f perf-bundle.yml \
-      --set imagePullSecrets.allowNone=true \
+      --set imagePullSecrets.allowNone={{ (rhacs_image_pull_secret_username == "") }} \
+      {{  (rhacs_image_pull_secret_username == "" ) | ternary("", "--set imagePullSecrets.username=" + rhacs_image_pull_secret_username) }} \
+      {{  (rhacs_image_pull_secret_password == "" ) | ternary("", "--set imagePullSecrets.password=" + rhacs_image_pull_secret_password) }} \
+      {{  (rhacs_image_main_registry == "" )        | ternary("", "--set image.main.registry=" + rhacs_image_main_registry) }} \
+      {{  (rhacs_image_main_tag == "" )             | ternary("", "--set image.main.tag=" + rhacs_image_main_tag) }} \
       --set clusterName={{ cluster_name }} \
       --set exposeMonitoring=true
   environment:

--- a/OCP-4.X/vars/install-common-vars.yml
+++ b/OCP-4.X/vars/install-common-vars.yml
@@ -122,7 +122,10 @@ openshift_ovn_image: "{{ lookup('env', 'OVN_IMAGE')|default('', true) }}"
 
 # RHACS
 rhacs_enable: "{{ lookup('env', 'RHACS_ENABLE')|default(false, true) }}"
-
+rhacs_image_pull_secret_username: "{{ lookup('env', 'RHACS_IMAGE_PULL_SECRET_USERNAME')|default('', true) }}"
+rhacs_image_pull_secret_password: "{{ lookup('env', 'RHACS_IMAGE_PULL_SECRET_PASSWORD')|default('', true) }}"
+rhacs_image_main_registry: "{{ lookup('env', 'RHACS_IMAGE_MAIN_REGISTRY')|default('', true) }}"
+rhacs_image_main_tag: "{{ lookup('env', 'RHACS_IMAGE_MAIN_TAG')|default('', true) }}"
 
 # Thanos
 thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"

--- a/docs/ocp4_common_env_var.md
+++ b/docs/ocp4_common_env_var.md
@@ -281,6 +281,30 @@ Password for the first super user.
 Default: No default.
 Postgresql database super user password.
 
+### RHACS_ENABLE
+Default: False
+An option to enable installation of ACS.
+
+### RHACS_IMAGE_MAIN_REGISTRY
+Default: ''
+Specify the image source when installing ACS. The most recent public release is
+the default install.
+
+### RHACS_IMAGE_MAIN_TAG
+Default: ''
+Specify the image tag when installing ACS. The most recent public release is the
+default install.
+
+### RHACS_IMAGE_PULL_SECRET_USERNAME
+Default: ''
+The username to allow access to a registry that requires authentication when
+installing ACS.
+
+### RHACS_IMAGE_PULL_SECRET_PASSWORD
+Default: ''
+The passowrd to allow access to a registry that requires authentication when
+installing ACS.
+
 ### THANOS_ENABLE
 Default: False
 Turn on remote_write to a thanos instance


### PR DESCRIPTION
### Description

As per title, with this change the main ACS image version can be specified in order to test non-latest candidates.

### Fixes
