### PR TITLE
Add ovn-sbdb-relay deployment to post-install

### DIFF
--- a/OCP-4.X/roles/post-install/defaults/main.yml
+++ b/OCP-4.X/roles/post-install/defaults/main.yml
@@ -1,0 +1,1 @@
+ovn_namespace: openshift-ovn-kubernetes 

--- a/OCP-4.X/roles/post-install/files/sbdb-relay.sh
+++ b/OCP-4.X/roles/post-install/files/sbdb-relay.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Script to deploy and verify deployment of the ovnkube-sbdb-relay
+# ./sbdb-relay.sh deploy|verify
+#
+
+OVN_NS=openshift-ovn-kubernetes
+
+if [[ "$1" == "deploy" ]]; then
+  OVNMASTER_PODS=($(oc get po -o wide -n ${OVN_NS} | awk '/ovnkube-master/{ print $1 }'))
+
+  echo "Deploying SBDB"
+  for POD in "${OVNMASTER_PODS[@]}"; do
+      oc logs ${POD} -c ovnkube-master | grep relay.go
+      if [[ $? -eq 0 ]]; then
+        echo "Found ovnkube-master leader: ${POD}"
+        YAML=$(oc logs ${POD} -c ovnkube-master | awk '/\-\-\-/,/^\w[0-9]{4}/' | head -n -1)
+        echo "${YAML}" | oc create -f -
+        break
+      else
+        echo "${POD} does not contain relay yaml"
+      fi
+  done
+elif [[ "$1" == "verify" ]]; then
+  SBDB_IPS=($(oc get po -o wide -n ${OVN_NS} | awk '/sbdb-relay/{ print $6 }'))
+  SBDB_IPS_STR="${SBDB_IPS[@]}"
+  OVNKUBE_PODS=($(oc get po -n ${OVN_NS} | awk '/ovnkube-node/{ print $1 }'))
+  NODE_COUNT=${#OVNKUBE_PODS[@]}
+  declare -A ready
+  
+  echo "SBDB IPs: ${SBDB_IPS_STR}"
+
+  # Populate array tracking node readiness state
+  for PODS in "${OVNKUBE_PODS[@]}"; do
+    ready[${PODS}]=false
+  done
+  
+  # Check SBDB connection of each ovn-controller
+  READY_NODES=0
+  while [ "${READY_NODES}" -lt "${NODE_COUNT}" ] ; do
+    for POD in "${OVNKUBE_PODS[@]}"; do
+      if ! ${ready[${POD}]}; then
+        echo "Searching pod ${POD} for SBDB IPs."
+        oc logs ${POD} -c ovn-controller | grep -E ${SBDB_IPS_STR// /|}
+        if [ $? -eq 0 ]; then
+          READY_NODES=$((${READY_NODES}+1));
+          echo "Found ${POD} using relays (Ready ${READY_NODES}/${NODE_COUNT})."
+          ready[${POD}]=true
+          break
+        fi
+      fi
+    done
+  done
+
+  echo "All ${READY_NODES} ovnkube-nodes connected to SBDB relays."
+else
+  echo "$(basename "$0") requires one of two parameters: deploy or verify"
+fi

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -156,24 +156,35 @@
     - item.toggle|bool
     - platform == "osp"
 
-- name: Scale CVO Down for OVNKubernetes image patching
-  command: oc scale -n openshift-cluster-version deployment.apps/cluster-version-operator --replicas=0
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-  when: openshift_toggle_ovn_patch|bool
-
-- name: Patch new OVNKubernetes Image
-  command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}}
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-  when: openshift_toggle_ovn_patch|bool
-
-- name: Pause the rollout to begin
-  pause:
-    seconds: 10
-
-- name: See if OVNK new images have rolled out
-  shell: oc rollout status -n openshift-ovn-kubernetes ds/ovnkube-node
+- name: OVN block
+  block:
+  - name: Scale CVO Down for OVNKubernetes image patching
+    command: oc scale -n openshift-cluster-version deployment.apps/cluster-version-operator --replicas=0
+  
+  - name: Patch new OVNKubernetes Image
+    command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}}
+  
+  - name: Pause the rollout to begin
+    pause:
+      seconds: 10
+  
+  - name: Wait for OVNK new node images to roll out
+    command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-node
+  
+  - name: Wait for OVNK new master images to roll out
+    command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-master
+  
+  - name: OVN SBDB block
+    block:
+    - name: Deploy ovnkube-sbdb-relay
+      script: sbdb-relay.sh deploy
+    
+    - name: Wait for OVNK sbdb-relay images to roll out
+      command: oc rollout status -n {{ ovn_namespace }} deployment.apps/ovnkube-sbdb-relay
+    
+    - name: Verify ovnkube-sbdb-relay connectivity
+      script: sbdb-relay.sh verify
+    when: openshift_toggle_ovn_relay|bool
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_ovn_patch|bool
@@ -246,18 +257,22 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_workload_node|bool
 
-- name: Copy new cluster-monitoring-config
-  template:
-    src: cluster-monitoring-config.yml.j2
-    dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml"
-  when: openshift_toggle_infra_node|bool
+- block:
+  - name: Copy new cluster-monitoring-config
+    template:
+      src: cluster-monitoring-config.yml.j2
+      dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml"
+    register: copy_yaml
+  
+  - set_fact:
+      cluster_monitoring_yaml_path: "{{ copy_yaml.dest }}"
 
-- name: Replace the cluster-monitoring-config ConfigMap
-  shell: |
-    oc create -f {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml
-  ignore_errors: yes
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
+  - name: Replace the cluster-monitoring-config ConfigMap
+    shell: |
+      oc create -f {{ cluster_monitoring_yaml_path }}
+    ignore_errors: yes
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_infra_node|bool
 
 # Need this to steer cluster-monitoring-operator onto the infra nodes

--- a/OCP-4.X/vars/install-common-vars.yml
+++ b/OCP-4.X/vars/install-common-vars.yml
@@ -47,6 +47,7 @@ openshift_network_type: "{{ lookup('env', 'OPENSHIFT_NETWORK_TYPE')|default('Ope
 # Post-install configuration
 openshift_post_install_poll_attempts: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS')|default(600, true) }}"
 openshift_toggle_infra_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_INFRA_NODE')|default(true, true) }}"
+openshift_toggle_ovn_relay: "{{ lookup('env', 'OPENSHIFT_TOGGLE_OVN_RELAY')|default(false, true) }}"
 openshift_toggle_workload_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_WORKLOAD_NODE')|default(true, true) }}"
 
 ## Mutable Grafana

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -151,6 +151,18 @@ The storage class for the alertmanager servers.
 ### OPENSHIFT_ALERTMANAGER_STORAGE_SIZE
 Default: `2Gi`
 
+### OPENSHIFT_TOGGLE_OVN_RELAY
+Default: `false`
+Toggle the deployment of the OVN SBSB relay.
+
+### OVN_PATCH
+Default: `false`
+Toggle to patch and replace the default OVN deployment image.
+
+### OVN_IMAGE
+Default: `nil`
+The OVN image that we will use to replace the default, requires `OVN_PATCH` to be `true`.
+
 ### WORKLOAD_AWS_AZ_SUFFIX
 Default: `d`
 Default EC2 availability zone(AZ) is set to `d`, but some regions do not have the AZ `d`, in that case you can set this to some other letter.


### PR DESCRIPTION
### Description
In order to test the sbdb relay functionality.

### Fixes
- Adds sbdb relay functionality
- Create `post-install` default vars
- Small related changes