### PR TITLE
Reducing clusterexpiry to 7 days

### DIFF
--- a/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
@@ -57,7 +57,7 @@
 
 - name: Append a tag to the resource group to extend the lifetime of the cluster to 40 days
   shell: |
-    az group update -n {{rhcos_cluster_name.stdout}}-rg --set tags.'openshift_expiryDate'=$(date -d "+40 days" +%F)
+    az group update -n {{rhcos_cluster_name.stdout}}-rg --set tags.'openshift_expiryDate'=$(date -d "+{{ azure_cluster_expiry | default(7,true) }} days" +%F)
 
 - name: Get the kubeconfig off of the orchestration host
   fetch:

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -6,6 +6,7 @@ azure_service_principal_client_id: "{{ lookup('env', 'AZURE_SERVICE_PRINCIPAL_CL
 azure_service_principal_client_secret: "{{ lookup('env', 'AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET') }}"
 azure_base_domain_resource_group_name: "{{ lookup('env', 'AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME') }}"
 azure_region: "{{ lookup('env', 'AZURE_REGION') }}"
+azure_cluster_expiry: "{{lookup('env', 'AZURE_CLUSTER_EXPIRY') |  default(7, true) }}"
 
 # Cluster Configuration
 openshift_base_domain: "{{ lookup('env', 'OPENSHIFT_BASE_DOMAIN') }}"

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -44,6 +44,10 @@ The resource group in which the base domain is located.
 Default: No default.
 The Azure region to install on to. Example: `centralus`
 
+### AZURE_CLUSTER_EXPIRY
+Default: 7
+The cluster will expire after 7 days by setting `openshift_expiryDate` to to `+7`. Unless you pass a different value using this environment variable.
+
 ### OPENSHIFT_BASE_DOMAIN
 Default: No default.
 The base domain for the cluster.


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
Cluster expiry was set to lengthy 40 days period, unknowingly, a test cluster remaining running could cost thousands of :dollar: to us, reducing it to 7 days with an option to make it even shorter if needed by defining the variable.


@mohit-sheth @jtaleric 