### PR TITLE
have image_override be of higher precedence than binary_url

### DIFF
--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -95,7 +95,7 @@
       cp oc /usr/local/bin/oc
       cp kubectl /usr/local/bin/kubectl
 
-  when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
+  when: not openshift_install_installer_from_source|bool and openshift_install_release_image_override != ""
 
 - name: Build installer from source
   block:
@@ -244,7 +244,7 @@
        ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
        chmod +x openshift-install
 
-  when: openshift_install_binary_url != ""
+  when: openshift_install_binary_url != "" and openshift_install_release_image_override == ""
 
 - name: Setup install-config.yaml
   template:


### PR DESCRIPTION
### Description
This way if we need a build other than the latest nightly, it can be overridden in airflow