### PR TITLE
force copy oc clients to avoid 'text file busy'

### DIFF
--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -35,8 +35,8 @@
     set -o pipefail
     cd {{ ansible_user_dir }}/{{ dynamic_deploy_path }}/bin
     tar xzf "{{ openshift_client_location | basename }}"
-    cp oc /usr/local/bin/oc
-    cp kubectl /usr/local/bin/kubectl
+    cp -f oc /usr/local/bin/oc
+    cp -f kubectl /usr/local/bin/kubectl
 
 - name: Setup config for container registry
   template:
@@ -92,8 +92,8 @@
       oc adm release extract --tools {{ openshift_install_release_image_override }}
       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
       chmod +x openshift-install
-      cp oc /usr/local/bin/oc
-      cp kubectl /usr/local/bin/kubectl
+      cp -f oc /usr/local/bin/oc
+      cp -f kubectl /usr/local/bin/kubectl
 
   when: not openshift_install_installer_from_source|bool and openshift_install_release_image_override != ""
 


### PR DESCRIPTION
As we have multiple clusters on the same jump host the oc client location is common for all of them. The copy command will fail wth "Text file busy" if we are running some command in the background.
The -f option will force the copy
