### PR TITLE
add cluster name into the infra and workload machinesets name to iden…

### DIFF
--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -6,7 +6,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-a
+    name: infra-{{cluster_name.stdout}}-a
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -15,7 +15,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
       spec:
         metadata:
           creationTimestamp: null
@@ -69,7 +69,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-b
+    name: infra-{{cluster_name.stdout}}-b
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -78,7 +78,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-b
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
     template:
       metadata:
         creationTimestamp: null
@@ -86,7 +86,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-b
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
       spec:
         metadata:
           creationTimestamp: null
@@ -132,7 +132,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-c
+    name: infra-{{cluster_name.stdout}}-c
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -141,7 +141,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-c
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-c
     template:
       metadata:
         creationTimestamp: null
@@ -149,7 +149,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-c
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-c
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -78,7 +78,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-b
     template:
       metadata:
         creationTimestamp: null
@@ -86,7 +86,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-b
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -4,9 +4,9 @@ metadata:
   generation: 1
   labels:
     {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-  name: workload-a
+  name: workload-{{cluster_name.stdout}}-a
   namespace: openshift-machine-api
-  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/workload-a
+  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/workload-{{cluster_name.stdout}}-a
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-a
+      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{cluster_name.stdout}}-a
   template:
     metadata:
       creationTimestamp: null
@@ -22,7 +22,7 @@ spec:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{cluster_name.stdout}}-a
     spec:
       metadata:
         creationTimestamp: null


### PR DESCRIPTION
…tify the resource owner on provider side

### Description
https://github.com/cloud-bulldozer/scale-ci-deploy/issues/170

### Fixes
Add cluster name into the name of infra and workload machineset to help identify the resource from provider side.