### PR TITLE
move cluster name to the begining of gcp infra and workload machinesets

### DIFF
--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -6,7 +6,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-{{cluster_name.stdout}}-a
+    name: {{cluster_name.stdout}}-infra-a
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -15,7 +15,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
     template:
       metadata:
         creationTimestamp: null
@@ -23,7 +23,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
       spec:
         metadata:
           creationTimestamp: null
@@ -69,7 +69,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-{{cluster_name.stdout}}-b
+    name: {{cluster_name.stdout}}-infra-b
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -78,7 +78,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-b
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
     template:
       metadata:
         creationTimestamp: null
@@ -86,7 +86,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-b
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
       spec:
         metadata:
           creationTimestamp: null
@@ -132,7 +132,7 @@ items:
     generation: 1
     labels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: infra-{{cluster_name.stdout}}-c
+    name: {{cluster_name.stdout}}-infra-c
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -141,7 +141,7 @@ items:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-c
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
     template:
       metadata:
         creationTimestamp: null
@@ -149,7 +149,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{cluster_name.stdout}}-c
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
       spec:
         metadata:
           creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -4,9 +4,9 @@ metadata:
   generation: 1
   labels:
     {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-  name: workload-{{cluster_name.stdout}}-a
+  name: {{cluster_name.stdout}}-workload-a
   namespace: openshift-machine-api
-  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/workload-{{cluster_name.stdout}}-a
+  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-workload-a
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{cluster_name.stdout}}-a
+      {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
   template:
     metadata:
       creationTimestamp: null
@@ -22,7 +22,7 @@ spec:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{cluster_name.stdout}}-a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
     spec:
       metadata:
         creationTimestamp: null


### PR DESCRIPTION
### Description
https://github.com/cloud-bulldozer/scale-ci-deploy/issues/169
https://github.com/cloud-bulldozer/scale-ci-deploy/issues/170


### Fixes
From To Hung in QE team:

> We do see this problem (firewall not cleaned up) when a machine is created using yaml especially if the machine does not have a name that matches the cluster infra id.
> Most, if not all, of our automation do not create machine using a yaml.

So If we include cluster infra id to the machine name, both the firewall and storage issues could be fixed.

https://github.com/cloud-bulldozer/scale-ci-deploy/pull/171 did a change to include cluster-name in name of gcp infra and workload machinesets, but the cluster-name is in the middle.

After reading https://coreos.slack.com/archives/C68TNFWA2/p1631654865169700?thread_ts=1631629766.139500&cid=C68TNFWA2, I checked the code, destroyer checks clustername as prefix https://github.com/openshift/installer/blob/422e17192462f2b5d5572d8600096949d3c14634/pkg/destroy/gcp/gcp.go#L220, so begin with clustername is necessary, that means we need to change name: infra-{{cluster_name.stdout}}-a to something like name: {{cluster_name.stdout}}-infra-a. @mohit-sheth Please help to review and let me know if you think there is any side effect of moving 'infra' and 'workload' from beginning to the middle.