### PR TITLE
Break ovn_relay out of ovn_patch block

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -167,21 +167,23 @@
   
   - name: Wait for OVNK new master images to roll out
     command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-master
-  
-  - name: OVN SBDB block
-    block:
-    - name: Deploy ovnkube-sbdb-relay
-      script: sbdb-relay.sh deploy
-    
-    - name: Wait for OVNK sbdb-relay images to roll out
-      command: oc rollout status -n {{ ovn_namespace }} deployment.apps/ovnkube-sbdb-relay
-    
-    - name: Verify ovnkube-sbdb-relay connectivity
-      script: sbdb-relay.sh verify
-    when: openshift_toggle_ovn_relay|bool
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_ovn_patch|bool
+
+- name: OVN SBDB block
+  block:
+  - name: Deploy ovnkube-sbdb-relay
+   script: sbdb-relay.sh deploy
+
+  - name: Wait for OVNK sbdb-relay images to roll out
+    command: oc rollout status -n {{ ovn_namespace }} deployment.apps/ovnkube-sbdb-relay
+
+  - name: Verify ovnkube-sbdb-relay connectivity
+    script: sbdb-relay.sh verify
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  when: openshift_toggle_ovn_relay|bool
 
 - name: Create machinesets
   shell: |


### PR DESCRIPTION
### Description
OVN is landing most changes upstream so we don't need to use `openshift_toggle_ovn_patch` in order to also use `openshift_toggle_ovn_relay`. 

### Fixes
We can standalone toggle `ovn_relay`.