### PR TITLE
set  kubeconfig_path to string constant

### DIFF
--- a/OCP-4.X/roles/cerberus_install/templates/cerberus.j2
+++ b/OCP-4.X/roles/cerberus_install/templates/cerberus.j2
@@ -1,6 +1,6 @@
 cerberus:
     distribution: {{ distribution }}                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: {{ kubeconfig_path }}                          # Path to kubeconfig
+    kubeconfig_path: /root/.kube/config                             # Path to kubeconfig
     port: {{ cerberus_port }}                                       # http server port where cerberus status is published
     watch_nodes: {{ watch_nodes }}                                  # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: {{ watch_cluster_operators }}          # Set to True for cerberus to monitor cluster operators


### PR DESCRIPTION
### Description

set kubeconfig_path to string /root/.kube/config, instead of a variable, since kubeconfig_path is always mounted to  /root/.kube/config in podman.

### Fixes
Fixes cloud-bulldozer/scale-ci-deploy/issues/180