### PR TITLE
Open port range 20000-30109

### DIFF
--- a/OCP-4.X/roles/post-config-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-aws/tasks/main.yml
@@ -5,7 +5,7 @@
 # Performs:
 # * Opens firewall rules for workload/worker nodes for ssh (as well as for debugging workload pod ssh)
 # * Opens firewall rules for Network Tests P2P HostNetwork Tests
-#   Ports 2022 (tcp), 20000-20109 (tcp, udp), 32768-60999 (tcp, udp)
+#   Ports 2022 (tcp), 20000-30109 (tcp, udp), 32768-60999 (tcp, udp)
 # * Ensures ssh is started and running on nodes
 #
 
@@ -49,14 +49,14 @@
     - "{{ security_groups.stdout_lines }}"
   ignore_errors: yes
 
-- name: Add inbound rule to allow tcp traffic on port range 20000 to 20109
-  shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol tcp --port 20000-20109 --cidr 0.0.0.0/0
+- name: Add inbound rule to allow tcp traffic on port range 20000 to 30109
+  shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol tcp --port 20000-30109 --cidr 0.0.0.0/0
   with_items:
     - "{{ security_groups.stdout_lines }}"
   ignore_errors: yes
 
-- name: Add inbound rule to allow udp traffic on port range 20000 to 20109
-  shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol udp --port 20000-20109 --cidr 0.0.0.0/0
+- name: Add inbound rule to allow udp traffic on port range 20000 to 30109
+  shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol udp --port 20000-30109 --cidr 0.0.0.0/0
   with_items:
     - "{{ security_groups.stdout_lines }}"
   ignore_errors: yes

--- a/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
@@ -5,7 +5,7 @@
 # Performs:
 # * Opens firewall rules for workload/worker nodes for ssh (as well as for debugging workload pod ssh)
 # * Opens firewall rules for Network Tests P2P HostNetwork Tests
-#   Ports 2022 (tcp), 20000-20109 (tcp, udp), 32768-60999 (tcp, udp)
+#   Ports 2022 (tcp), 20000-30109 (tcp, udp), 32768-60999 (tcp, udp)
 #
 
 - name: Get cluster name
@@ -44,9 +44,9 @@
   shell: |
     az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-pbench-agent --nsg-name {{azure_sg.stdout}} --priority 102 --access Allow --description "scale-ci allow pbench-agent" --protocol Tcp --destination-port-ranges "2022"
 
-- name: Create network security group rule for tcp,udp network tests (20000-20109)
+- name: Create network security group rule for tcp,udp network tests (20000-30109)
   shell: |
-    az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-net --nsg-name {{azure_sg.stdout}} --priority 104 --access Allow --description "scale-ci allow tcp,udp network tests" --protocol "*" --destination-port-ranges "20000-20109"
+    az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-net --nsg-name {{azure_sg.stdout}} --priority 104 --access Allow --description "scale-ci allow tcp,udp network tests" --protocol "*" --destination-port-ranges "20000-30109"
 
 # Typically `net.ipv4.ip_local_port_range` is set to `32768 60999` in which uperf will pick a few random ports to send flags over.
 # Currently there is no method outside of sysctls to control those ports

--- a/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
@@ -5,7 +5,7 @@
 # Performs:
 # * Opens firewall rules for workload/worker nodes for ssh (as well as for debugging workload pod ssh)
 # * Opens firewall rules for Network Tests P2P HostNetwork Tests
-#   Ports 2022 (tcp), 20000-20109 (tcp, udp), 32768-60999 (tcp, udp)
+#   Ports 2022 (tcp), 20000-30109 (tcp, udp), 32768-60999 (tcp, udp)
 #
 
 - name: Get cluster name
@@ -53,9 +53,9 @@
   shell: |
     gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-pbench --network {{ gcp_network.stdout }} --direction INGRESS --priority 103 --description "scale-ci allow pbench-agents" --allow tcp:2022
 
-- name: Create firewall rule for tcp,udp network tests (20000-20109)
+- name: Create firewall rule for tcp,udp network tests (20000-30109)
   shell: |
-    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-net --network {{ gcp_network.stdout }} --direction INGRESS --priority 104 --description "scale-ci allow tcp,udp network tests" --rules tcp,udp:20000-20109 --action allow
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-net --network {{ gcp_network.stdout }} --direction INGRESS --priority 104 --description "scale-ci allow tcp,udp network tests" --rules tcp,udp:20000-30109 --action allow
 
 # Typically `net.ipv4.ip_local_port_range` is set to `32768 60999` in which uperf will pick a few random ports to send flags over.
 # Currently there is no method outside of sysctls to control those ports

--- a/OCP-4.X/roles/post-config-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-osp/tasks/main.yml
@@ -6,7 +6,7 @@
 # * Add public ip to workload node
 # * Opens firewall rules for workload/worker nodes for ssh (as well as for debugging workload pod ssh)
 # * Opens firewall rules for Network Tests P2P HostNetwork Tests
-#   Ports 2022 (tcp), 20000-20109 (tcp, udp), 32768-60999 (tcp, udp)
+#   Ports 2022 (tcp), 20000-30109 (tcp, udp), 32768-60999 (tcp, udp)
 #
 
 - block:
@@ -53,11 +53,11 @@
 # Typically `net.ipv4.ip_local_port_range` is set to `32768 60999` in which uperf will pick a few random ports to send flags over.
 # Currently there is no method outside of sysctls to control those ports
 # See pbench issue #1238 - https://github.com/distributed-system-analysis/pbench/issues/1238
-- name: Allow traffic over tcp/udp ports (20000-20109, 32768-60999) for HostNetwork Network Tests
+- name: Allow traffic over tcp/udp ports (20000-30109, 32768-60999) for HostNetwork Network Tests
   shell: |
     . {{ ansible_user_dir }}/{{osp_project_name}}rc
-    openstack security group rule create --ingress --protocol tcp --dst-port 20000:20109 {{item}}
-    openstack security group rule create --ingress --protocol udp --dst-port 20000:20109 {{item}}
+    openstack security group rule create --ingress --protocol tcp --dst-port 20000:30109 {{item}}
+    openstack security group rule create --ingress --protocol udp --dst-port 20000:30109 {{item}}
     openstack security group rule create --ingress --protocol tcp --dst-port 32768:60999 {{item}}
     openstack security group rule create --ingress --protocol udp --dst-port 32768:60999 {{item}}
   with_items: "{{security_groups.stdout_lines}}"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Create security groups for port range 20000-30109 rather than the original 20000-20109 in order to make NodePort services work. We need this PR to be merged before https://github.com/cloud-bulldozer/benchmark-wrapper/pull/402
cc: @josecastillolema


