### PR TITLE
rewrite and fix indexing cluster-install-timings

### DIFF
--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -13,6 +13,7 @@ timestamp = datetime.now().strftime("%Y-%m-%dT%T")
 CLUSTER_NAME = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.infrastructureName}'").read()
 CLUSTER_VERSION = os.popen(oc_command + " get clusterversion --no-headers -o custom-columns=name:{.status.desired.version}").read()
 PLATFORM = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.platformStatus.type}'").read()
+NETWORK_TYPE = os.popen(oc_command + " describe network.config/cluster | grep 'Network Type' |  awk '{print $3}' | head -n 1").read()
 
 masters = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/master --no-headers=true | wc -l").read())
 workers = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= | wc -l").read())
@@ -85,6 +86,7 @@ for action in output:
     data = {
         "uuid" : UUID,
         "platform": PLATFORM,
+        "network_type": NETWORK_TYPE,
         "cluster_version": CLUSTER_VERSION,
         "master_count": masters,
         "worker_count": workers,

--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -15,7 +15,7 @@ CLUSTER_VERSION = os.popen(oc_command + " get clusterversion --no-headers -o cus
 PLATFORM = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.platformStatus.type}'").read()
 
 masters = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/master --no-headers=true | wc -l").read())
-workers = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/worker --no-headers=true | wc -l").read())
+workers = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= | wc -l").read())
 workload = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/workload --no-headers=true | wc -l").read())
 infra = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/infra --no-headers=true | wc -l").read())
 all = int(os.popen(oc_command + " get nodes --no-headers=true | wc -l").read())
@@ -90,7 +90,7 @@ for action in output:
         "worker_count": workers,
         "infra_count": infra,
         "workload_count": workload,
-        "total_node_    count": all,
+        "total_node_count": all,
         "cluster_name": CLUSTER_NAME,
         "action": action,
         "duration": output[action],

--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -53,9 +53,7 @@ for i in lines[:-1]:
 output = {}
 for i in data:
     title = i[0]
-    time = i[1].lstrip().rstrip()
-    print(title)
-    print(time)
+    time = i[1].strip()
     temp = 0
     if 'm' in time:
         time = time.split('m')
@@ -81,7 +79,7 @@ headers = {
     'Cache-Control': 'no-cache'
 }
 
-print("Indexing data to Elasticsearch")
+print(f"Indexing data to Elasticsearch: {ES}/openshift-install-timings")
 for action in output:
     data = {
         "uuid" : UUID,

--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -1,0 +1,101 @@
+import os
+import uuid
+import json
+import requests
+from datetime import datetime
+
+UUID = str(uuid.uuid4())
+LOG_FILE = os.getenv('INSTALL_LOG', '/root/openshift_install.log')
+ES = os.getenv('ES_SERVER', 'http://elastic:9200')
+oc_command = '/usr/local/bin/oc'
+timestamp = datetime.now().strftime("%Y-%m-%dT%T")
+
+CLUSTER_NAME = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.infrastructureName}'").read()
+PLATFORM = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.platformStatus.type}'").read()
+
+masters = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/master --no-headers=true | wc -l").read())
+workers = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/worker --no-headers=true | wc -l").read())
+workload = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/workload --no-headers=true | wc -l").read())
+infra = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/infra --no-headers=true | wc -l").read())
+all = int(os.popen(oc_command + " get nodes --no-headers=true | wc -l").read())
+
+###Parse the install log file 
+
+#Read last 20 lines from log file
+lines = os.popen("cat "+ LOG_FILE + " | tail -n 20").read()
+
+"""
+Sample Input - 
+time="2022-02-12T06:50:32Z" level=info msg="Access the OpenShift web-console here: devcluster.openshift.com"
+time="2022-02-12T06:50:32Z" level=info msg="Login to the console with user: \"kubeadmin\", and password: \"abcdef""
+time="2022-02-12T06:50:32Z" level=debug msg="Time elapsed per stage:"
+time="2022-02-12T06:50:32Z" level=debug msg="           cluster: 5m34s"
+time="2022-02-12T06:50:32Z" level=debug msg="         bootstrap: 31s"
+time="2022-02-12T06:50:32Z" level=debug msg="Bootstrap Complete: 14m36s"
+time="2022-02-12T06:50:32Z" level=debug msg="               API: 2m13s"
+time="2022-02-12T06:50:32Z" level=debug msg=" Bootstrap Destroy: 1m9s"
+time="2022-02-12T06:50:32Z" level=debug msg=" Cluster Operators: 10m58s"
+time="2022-02-12T06:50:32Z" level=info msg="Time elapsed: 32m59s
+
+"""
+
+#'Time elapsed per stage' string is common in all the log files, and all required timings are found below its index.
+x = lines.index("Time elapsed per stage")
+lines = (lines[x:].split("\n"))[1:]
+data = []
+for i in lines[:-1]:
+    x = i[i.index('msg="')+5:]
+    x = x.lstrip().rstrip().split(':')
+    data.append(x)
+
+output = {}
+for i in data:
+    title = i[0]
+    time = i[1].lstrip().rstrip()
+    print(title)
+    print(time)
+    temp = 0
+    if 'm' in time:
+        time = time.split('m')
+
+        min = int(time[0])*60
+        temp += min
+        sec = int(time[1].split('s')[0])
+        temp += sec
+    else:
+        sec = int(time.split('s')[0])
+        temp += sec
+    output[title] = temp
+
+"""
+Sample Output - 
+{'cluster': 334, 'bootstrap': 31, 'Bootstrap Complete': 876, 'API': 133, 'Bootstrap Destroy': 69, 'Cluster Operators': 658, 'Time elapsed': 1979}
+"""
+
+
+### Index data to Elasticsearch
+headers = {
+    'Content-type': 'application/json',
+    'Cache-Control': 'no-cache'
+}
+
+print("Indexing data to Elasticsearch")
+for action in output:
+    data = {
+        "uuid" : UUID,
+        "platform": PLATFORM,
+        "master_count": masters,
+        "worker_count": workers,
+        "infra_count": infra,
+        "workload_count": workload,
+        "total_node_    count": all,
+        "cluster_name": CLUSTER_NAME,
+        "action": action,
+        "duration": output[action],
+        "timestamp": timestamp
+    }
+    print(data)
+    data = json.dumps(data)
+    response = requests.post(ES+'/openshift-install-timings/_doc/', headers=headers, data=data)
+print("Data Successfully indexed to ES on index - openshift-install-timings")
+print("UUID :- " + UUID)

--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -11,6 +11,7 @@ oc_command = '/usr/local/bin/oc'
 timestamp = datetime.now().strftime("%Y-%m-%dT%T")
 
 CLUSTER_NAME = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.infrastructureName}'").read()
+CLUSTER_VERSION = os.popen(oc_command + " get clusterversion --no-headers -o custom-columns=name:{.status.desired.version}").read()
 PLATFORM = os.popen(oc_command + " get infrastructure cluster -o jsonpath='{.status.platformStatus.type}'").read()
 
 masters = int(os.popen(oc_command + " get nodes -l node-role.kubernetes.io/master --no-headers=true | wc -l").read())
@@ -84,6 +85,7 @@ for action in output:
     data = {
         "uuid" : UUID,
         "platform": PLATFORM,
+        "cluster_version": CLUSTER_VERSION,
         "master_count": masters,
         "worker_count": workers,
         "infra_count": infra,

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -28,9 +28,12 @@
 
 - name: Index install Timings
   script: index-install-timings.py
+  args:
+    executable: python
   environment:
     ES_SERVER: "{{ es_server }}"
     INSTALL_LOG: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/.openshift_install.log"
+    KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: AWS Block of tasks
   block:

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -26,9 +26,9 @@
   set_fact:
     user_data_secret: "worker-user-data"
 
-- name: Index install log
+- name: Index install Timings
   script:
-    cmd: index-install-data.sh
+    cmd: index-install-timings.py
   environment:
     ES_SERVER: "{{ es_server }}"
     INSTALL_LOG: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/.openshift_install.log"

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -27,8 +27,7 @@
     user_data_secret: "worker-user-data"
 
 - name: Index install Timings
-  script:
-    cmd: index-install-timings.py
+  script: index-install-timings.py
   environment:
     ES_SERVER: "{{ es_server }}"
     INSTALL_LOG: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/.openshift_install.log"


### PR DESCRIPTION
### Description
The current script for indexing install timings in post-install was broken and some of the important data points are not being indexed.

### Fixes
Rewrite install time parsing from log file in python.