### PR TITLE
Disable cert verification in install timings indexing

### DIFF
--- a/OCP-4.X/roles/post-install/files/index-install-timings.py
+++ b/OCP-4.X/roles/post-install/files/index-install-timings.py
@@ -98,6 +98,6 @@ for action in output:
     }
     print(data)
     data = json.dumps(data)
-    response = requests.post(ES+'/openshift-install-timings/_doc/', headers=headers, data=data)
+    response = requests.post(ES+'/openshift-install-timings/_doc/', headers=headers, data=data, verify=False)
 print("Data Successfully indexed to ES on index - openshift-install-timings")
 print("UUID :- " + UUID)


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We have enabled TLS in ES and it's using a self-signed cert

### Fixes
