### PR TITLE
remove task for fetching alibaba region in post install

### DIFF
--- a/OCP-4.X/roles/post-config-on-alibaba/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-alibaba/tasks/main.yml
@@ -16,13 +16,6 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
-- name: (Alibaba) Get cluster region
-  shell: |
-    {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.regionId}}'{%endraw%}
-  register: alibaba_region
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-
 # TODO - Check and Fix Public Ip allocation to the Alibaba workload machine instance.
 - block:
     - name: Get public ip of the workload node
@@ -40,7 +33,7 @@
 - name: Get security groups
   shell: |
     aliyun ecs DescribeSecurityGroups \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupName {{ rhcos_cluster_name.stdout }}-sg-worker \
       | jq .SecurityGroups.SecurityGroup[].SecurityGroupId
   register: security_groups
@@ -48,7 +41,7 @@
 - name: Add inbound rule to allow traffic on 22
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "tcp" \
       --PortRange "22/22" \
@@ -60,7 +53,7 @@
 - name: Add inbound rule to allow traffic on 2022
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "tcp" \
       --PortRange "2022/2022" \
@@ -72,7 +65,7 @@
 - name: Add inbound rule to allow tcp traffic on port range 20000 to 30109
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "tcp" \
       --PortRange "20000/30109" \
@@ -84,7 +77,7 @@
 - name: Add inbound rule to allow udp traffic on port range 20000 to 30109
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "udp" \
       --PortRange "20000/30109" \
@@ -99,7 +92,7 @@
 - name: Add inbound rule to allow tcp traffic on port range 32768 to 60999
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "tcp" \
       --PortRange "32768/60999" \
@@ -111,7 +104,7 @@
 - name: Add inbound rule to allow udp traffic on port range 32768 to 60999
   shell: |
     aliyun ecs AuthorizeSecurityGroup \
-      --RegionId {{ alibaba_region.stdout }} \
+      --RegionId {{ alibaba_region }} \
       --SecurityGroupId {{ item }} \
       --IpProtocol "udp" \
       --PortRange "32768/60999" \

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -139,13 +139,6 @@
 
 - name: Alibaba Block of tasks
   block:
-    - name: (Alibaba) Get cluster region
-      shell: |
-        {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.regionId}}'{%endraw%}
-      register: alibaba_region
-      environment:
-        KUBECONFIG: "{{ kubeconfig_path }}"
-
     - name: (Alibaba) Get machineset name of a worker node
       shell: |
         {%raw%}oc get machinesets --no-headers -n openshift-machine-api | awk {'print $1'} | awk 'NR==1{print $1}'{%endraw%}

--- a/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
@@ -10,14 +10,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: infra-{{alibaba_region.stdout}}a
+    name: infra-{{alibaba_region}}a
     namespace: openshift-machine-api
   spec:
     replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region.stdout}}a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region}}a
     template:
       metadata:
         creationTimestamp: null
@@ -25,7 +25,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region.stdout}}a
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region}}a
       spec:
         metadata:
           creationTimestamp: null
@@ -40,7 +40,7 @@ items:
             instanceType: {{ openshift_infra_node_instance_type }}
             kind: AlibabaCloudMachineProviderConfig
             ramRoleName: {{cluster_name.stdout}}-role-worker
-            regionId: {{alibaba_region.stdout}}
+            regionId: {{alibaba_region}}
             resourceGroup:
               name: {{cluster_name.stdout}}-rg
               type: Name
@@ -76,10 +76,10 @@ items:
               - Key: sigs.k8s.io/cloud-provider-alibaba/origin
                 Value: ocp
               - Key: Name
-                Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region.stdout}}a
+                Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region}}a
               type: Tags
             vpcId: ""
-            zoneId: {{alibaba_region.stdout}}a
+            zoneId: {{alibaba_region}}a
           taints:
           - key: node-role.kubernetes.io/infra
             effect: NoSchedule
@@ -91,14 +91,14 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: infra-{{alibaba_region.stdout}}b
+    name: infra-{{alibaba_region}}b
     namespace: openshift-machine-api
   spec:
     replicas: 2
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region.stdout}}b
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region}}b
     template:
       metadata:
         creationTimestamp: null
@@ -106,7 +106,7 @@ items:
           {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
           {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
           {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region.stdout}}b
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{alibaba_region}}b
       spec:
         metadata:
           creationTimestamp: null
@@ -121,7 +121,7 @@ items:
             instanceType: {{ openshift_infra_node_instance_type }}
             kind: AlibabaCloudMachineProviderConfig
             ramRoleName: {{cluster_name.stdout}}-role-worker
-            regionId: {{alibaba_region.stdout}}
+            regionId: {{alibaba_region}}
             resourceGroup:
               name: {{cluster_name.stdout}}-rg
               type: Name
@@ -157,10 +157,10 @@ items:
               - Key: sigs.k8s.io/cloud-provider-alibaba/origin
                 Value: ocp
               - Key: Name
-                Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region.stdout}}b
+                Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region}}b
               type: Tags
             vpcId: ""
-            zoneId: {{alibaba_region.stdout}}b
+            zoneId: {{alibaba_region}}b
           taints:
           - key: node-role.kubernetes.io/infra
             effect: NoSchedule

--- a/OCP-4.X/roles/post-install/templates/alibaba-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-workload-node-machineset.yml.j2
@@ -6,14 +6,14 @@ metadata:
     {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
     {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
     {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-  name: workload-{{alibaba_region.stdout}}a
+  name: workload-{{alibaba_region}}a
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{alibaba_region.stdout}}a
+      {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{alibaba_region}}a
   template:
     metadata:
       creationTimestamp: null
@@ -21,7 +21,7 @@ spec:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
         {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
         {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{alibaba_region.stdout}}a
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: workload-{{alibaba_region}}a
     spec:
       metadata:
         creationTimestamp: null
@@ -36,7 +36,7 @@ spec:
           instanceType: {{openshift_workload_node_instance_type}}
           kind: AlibabaCloudMachineProviderConfig
           ramRoleName: {{cluster_name.stdout}}-role-worker
-          regionId: {{alibaba_region.stdout}}
+          regionId: {{alibaba_region}}
           resourceGroup:
             name: {{cluster_name.stdout}}-rg
             type: Name
@@ -73,10 +73,10 @@ spec:
             - Key: sigs.k8s.io/cloud-provider-alibaba/origin
               Value: ocp
             - Key: Name
-              Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region.stdout}}a
+              Value: {{cluster_name.stdout}}-vswitch-{{alibaba_region}}a
             type: Tags
           vpcId: ""
-          zoneId: {{alibaba_region.stdout}}a
+          zoneId: {{alibaba_region}}a
         taints:
         - key: node-role.kubernetes.io/workload
           effect: NoSchedule


### PR DESCRIPTION
### Description
ansible throws an error - no property stdout found. for the Alibaba region var which is registered in the post-install step.

Reusing the var from env for the fix.