### PR TITLE
Don't add workload node when openshift_debug_config is false

### DIFF
--- a/OCP-4.X/roles/post-config-on-alibaba/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-alibaba/tasks/main.yml
@@ -28,7 +28,9 @@
       add_host:
         name: "{{ workload_public_ip.stdout }}"
         groups: workload
-  when: openshift_toggle_workload_node|bool
+  when:
+    - openshift_toggle_workload_node|bool
+    - openshift_debug_config|bool
 
 - name: Get security groups
   shell: |

--- a/OCP-4.X/roles/post-config-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-aws/tasks/main.yml
@@ -27,7 +27,9 @@
       add_host:
         name: "{{ workload_public_ip.stdout }}"
         groups: workload
-  when: openshift_toggle_workload_node|bool
+  when:
+    - openshift_toggle_workload_node|bool
+    - openshift_debug_config|bool
 
 - name: Get VpcId
   shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName, VpcId]' --output text | column -t | grep {{ rhcos_cluster_name.stdout }} | awk '{print $7}' | grep -v '^$' | sort -u

--- a/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
@@ -25,7 +25,9 @@
       add_host:
         name: "{{ workload_public_ip.stdout }}"
         groups: workload
-  when: openshift_toggle_workload_node|bool
+  when:
+    - openshift_toggle_workload_node|bool
+    - openshift_debug_config|bool
 
 - name: Get node network security group
   shell: |

--- a/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
@@ -26,7 +26,9 @@
       add_host:
         name: "{{ workload_public_ip.stdout }}"
         groups: workload
-  when: openshift_toggle_workload_node|bool
+  when:
+    - openshift_toggle_workload_node|bool
+    - openshift_debug_config|bool
 
 - name: set service account
   shell: |

--- a/OCP-4.X/roles/post-config-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-osp/tasks/main.yml
@@ -31,7 +31,9 @@
       add_host:
         name: "{{ public_workload_fip.stdout }}"
         groups: workload
-  when: openshift_toggle_workload_node|bool
+  when:
+    - openshift_toggle_workload_node|bool
+    - openshift_debug_config|bool
 
 - name: get openshift infra id
   shell: |


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
When  openshift_toggle_workload_node=true and openshift_debug_config=false

The workload machineset will be created, but, the created workload node won't be added to the dynamic inventory

Therefore, these tasks will be skipped
https://github.com/cloud-bulldozer/scale-ci-deploy/blob/master/OCP-4.X/deploy-cluster.yml#L58-L131


This is required for alibaba cloud deployments, since at the moment it's not possible to assign a public IP to the created instances.


