### PR TITLE
add default resourcegroup id for alibaba

### DIFF
--- a/OCP-4.X/roles/openshift-install/templates/install-config-alibaba.yaml.j2
+++ b/OCP-4.X/roles/openshift-install/templates/install-config-alibaba.yaml.j2
@@ -37,6 +37,7 @@ fips: {{ fips }}
 platform:
  alibabacloud:
   region: {{ alibaba_region }}
+  resourceGroupID: {{ alibaba_resource_group_id }}
 publish: External
 pullSecret: |+
   {{ openshift_install_pull_secret | to_json }}

--- a/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
@@ -42,8 +42,8 @@ items:
             ramRoleName: {{cluster_name.stdout}}-role-worker
             regionId: {{alibaba_region}}
             resourceGroup:
-              name: {{cluster_name.stdout}}-rg
-              type: Name
+              id: {{alibaba_resource_group_id}}
+              type: ID
             securityGroups:
             - tags:
               - Key: kubernetes.io/cluster/{{cluster_name.stdout}}
@@ -123,8 +123,8 @@ items:
             ramRoleName: {{cluster_name.stdout}}-role-worker
             regionId: {{alibaba_region}}
             resourceGroup:
-              name: {{cluster_name.stdout}}-rg
-              type: Name
+              id: {{alibaba_resource_group_id}}
+              type: ID
             securityGroups:
             - tags:
               - Key: kubernetes.io/cluster/{{cluster_name.stdout}}

--- a/OCP-4.X/roles/post-install/templates/alibaba-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-workload-node-machineset.yml.j2
@@ -38,8 +38,8 @@ spec:
           ramRoleName: {{cluster_name.stdout}}-role-worker
           regionId: {{alibaba_region}}
           resourceGroup:
-            name: {{cluster_name.stdout}}-rg
-            type: Name
+            id: {{alibaba_resource_group_id}}
+            type: ID
           publicIp: true
           securityGroups:
           - tags:

--- a/OCP-4.X/vars/install-on-alibaba.yml
+++ b/OCP-4.X/vars/install-on-alibaba.yml
@@ -1,7 +1,7 @@
 ---
 # Cloud environment and authentication
 alibaba_region: "{{ lookup('env', 'ALIBABA_REGION') }}"
-#alibaba_base_domain_resource_group_id: 
+alibaba_resource_group_id: "{{ lookup('env', 'ALIBABA_RESOURCE_GROUP_ID') }}"
 aliyun_binary: "{{ lookup('env', 'ALIYUN_BINARY') | default('https://aliyuncli.alicdn.com/aliyun-cli-linux-3.0.32-amd64.tgz', true) }}"
 aliyun_access_key_id: "{{ lookup('env', 'ALIYUN_ACCESS_KEY_ID') }}"
 aliyun_access_key_secret: "{{ lookup('env', 'ALIYUN_ACCESS_KEY_SECRET') }}"


### PR DESCRIPTION
### Description
Alibaba cloud has limitations on the number of resource groups. At present we are creating a new resource group on every install which causes quota issues.
Changing it to use the pre-existing default resource group.