### PR TITLE
Default value for alibaba_region

### DIFF
--- a/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-cleanup/tasks/main.yml
@@ -18,7 +18,7 @@
         if [[ "{{ platform }}" == "alibaba" ]]
         then
           echo "Deleting Manually created Alibaba RAM users with ccoctl"
-          ccoctl alibabacloud delete-ram-users --region {{ alibaba_region }} --name ${cluster_name}
+          ccoctl alibabacloud delete-ram-users --region {{ alibaba_region|default() }} --name ${cluster_name}
         fi
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Will prevent errors like the following:
```
[2022-04-21, 19:11:37 EDT] {subprocess.py:89} INFO - fatal: [ec2-34-220-44-1.us-west-2.compute.amazonaws.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'alibaba_region' is undefined\n\nThe error appears to be in '/home/airflow/workspace/scale-ci-deploy/OCP-4.X/roles/openshift-cleanup/tasks/main.yml': line 12, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- block:\n    - name: Cleanup cluster\n      ^ here\n"}
```
cc: @amitsagtani97 

### Fixes
