### PR TITLE
Replace machine_type by instance_type

### DIFF
--- a/OCP-4.X/roles/openshift-install/templates/install-config-gcp.yaml.j2
+++ b/OCP-4.X/roles/openshift-install/templates/install-config-gcp.yaml.j2
@@ -5,14 +5,14 @@ compute:
   name: worker
   platform:
     gcp:
-      type: {{ openshift_worker_machine_type }}
+      type: {{ openshift_worker_instance_type }}
   replicas: {{ openshift_worker_count }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform:
     gcp:
-      type: {{ openshift_master_machine_type }}
+      type: {{ openshift_master_instance_type }}
   replicas: {{ openshift_master_count }}
 metadata:
   creationTimestamp: null

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -44,7 +44,7 @@ items:
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}
             kind: GCPMachineProviderSpec
-            machineType: {{openshift_infra_node_machine_type}}
+            machineType: {{openshift_infra_node_instance_type}}
             metadata:
               creationTimestamp: null
             networkInterfaces:
@@ -107,7 +107,7 @@ items:
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}
             kind: GCPMachineProviderSpec
-            machineType: {{openshift_infra_node_machine_type}}
+            machineType: {{openshift_infra_node_instance_type}}
             metadata:
               creationTimestamp: null
             networkInterfaces:
@@ -170,7 +170,7 @@ items:
               sizeGb: {{openshift_infra_node_volume_size}}
               type: {{openshift_infra_node_volume_type}}
             kind: GCPMachineProviderSpec
-            machineType: {{openshift_infra_node_machine_type}}
+            machineType: {{openshift_infra_node_instance_type}}
             metadata:
               creationTimestamp: null
             networkInterfaces:

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -43,7 +43,7 @@ spec:
             sizeGb: {{openshift_workload_node_volume_size}}
             type: {{openshift_workload_node_volume_type}}
           kind: GCPMachineProviderSpec
-          machineType: {{openshift_workload_node_machine_type}}
+          machineType: {{openshift_workload_node_instance_type}}
           metadata:
             creationTimestamp: null
           networkInterfaces:

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -13,8 +13,8 @@ openshift_cluster_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER_NAME') }}"
 openshift_master_count: "{{ lookup('env', 'OPENSHIFT_MASTER_COUNT')|default(3, true) }}"
 openshift_worker_count: "{{ lookup('env', 'OPENSHIFT_WORKER_COUNT')|default(5, true) }}"
 
-openshift_master_machine_type: "{{ lookup('env', 'OPENSHIFT_MASTER_MACHINE_TYPE')|default('n1-standard-4', true) }}"
-openshift_worker_machine_type: "{{ lookup('env', 'OPENSHIFT_WORKER_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+openshift_master_instance_type: "{{ lookup('env', 'OPENSHIFT_MASTER_INSTANCE_TYPE')|default('n1-standard-4', true) }}"
+openshift_worker_instance_type: "{{ lookup('env', 'OPENSHIFT_WORKER_INSTANCE_TYPE')|default('n1-standard-4', true) }}"
 
 openshift_master_root_volume_size: "{{ lookup('env', 'OPENSHIFT_MASTER_ROOT_VOLUME_SIZE')|default(64, true) }}"
 
@@ -22,8 +22,8 @@ openshift_worker_root_volume_size: "{{ lookup('env', 'OPENSHIFT_WORKER_ROOT_VOLU
 
 # Either machine.openshift.io or sigs.k8s.io
 machineset_metadata_label_prefix: "{{ lookup('env', 'MACHINESET_METADATA_LABEL_PREFIX')|default('machine.openshift.io', true) }}"
-openshift_infra_node_machine_type: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_MACHINE_TYPE')|default('n1-standard-4', true) }}"
-openshift_workload_node_machine_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+openshift_infra_node_instance_type: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_INSTANCE_TYPE')|default('n1-standard-4', true) }}"
+openshift_workload_node_instance_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE')|default('n1-standard-4', true) }}"
 
 openshift_infra_node_volume_size: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_VOLUME_SIZE')|default(64, true) }}"
 openshift_infra_node_volume_type: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_VOLUME_TYPE')|default('pd-ssd', true) }}"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We're using instance_type in airflow rather than machine_type

https://github.com/cloud-bulldozer/airflow-kubernetes/blob/07cd0814fe09583b6cf451f701d405ba1cb73a86/dags/openshift_nightlies/config/install/gcp/ovn.json#L17

