### PR TITLE
ovn: set RELEASE_VERSION to trigger CNO's node-before-master upgrade rollout

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -188,7 +188,7 @@
     command: oc scale -n openshift-cluster-version deployment.apps/cluster-version-operator --replicas=0
   
   - name: Patch new OVNKubernetes Image
-    command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}}
+    command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}} RELEASE_VERSION="5.0.0"
   
   - name: Pause the rollout to begin
     pause:


### PR DESCRIPTION
The CNO has specific logic to roll out ovnkube nodes before masters for two
reasons:

1) OVN requires ovn-controller be upgraded before northd to ensure
forwards compatibility; new ovn-controllers are backwards compatible
with older northds but not vice versa.

2) upgrading a bunch of nodes (especially > 200) at the same time
as restarting the southbound databases puts a lot of load on the DBs
as each restarted controller must pull the entire SB down. If the
DBs are restarting too, there are fewer DBs to spread the controller
load around, leading to longer poll intervals.

Thus, set RELEASE_VERSION to something "newer" than the current
OCP version to ensure we trigger the right CNO upgrade logic.

@rsevilla87 