### PR TITLE
PERFSCALE-1816 - Enables AWS Graviton2 tests.

### DIFF
--- a/OCP-4.X/deploy-cluster.yml
+++ b/OCP-4.X/deploy-cluster.yml
@@ -14,7 +14,7 @@
 
     - name: Include platform variables
       include_vars:
-        file: "vars/install-on-{{ platform }}.yml"
+        file: "vars/install-on-{{ (platform == 'aws-arm') | ternary('aws', platform) }}.yml"
 
     - name: Set dynamic scale-ci-deploy path
       set_fact:
@@ -43,7 +43,7 @@
     - role: cerberus_install
       when: cerberus_enable|bool
     - role: post-config-on-aws
-      when: openshift_post_config|bool and platform == "aws"
+      when: openshift_post_config|bool and (platform == "aws" or platform == "aws-arm")
     - role: post-config-on-azure
       when: openshift_post_config|bool and platform == "azure"
     - role: post-config-on-gcp
@@ -65,7 +65,7 @@
   pre_tasks:
     - name: Include platform variables
       include_vars:
-        file: "vars/install-on-{{ platform }}.yml"
+        file: "vars/install-on-{{ {{ (platform == 'aws-arm') | ternary('aws', platform) }} }}.yml"
   roles:
     - role: node-debug-config
       when: openshift_debug_config|bool
@@ -125,7 +125,7 @@
   pre_tasks:
     - name: Include platform variables
       include_vars:
-        file: "vars/install-on-{{ platform }}.yml"
+        file: "vars/install-on-{{ {{ (platform == 'aws-arm') | ternary('aws', platform) }} }}.yml"
   roles:
     - role: node-debug-config
       when: openshift_debug_config|bool

--- a/OCP-4.X/destroy-cluster.yml
+++ b/OCP-4.X/destroy-cluster.yml
@@ -12,7 +12,7 @@
 
     - name: Include platform variables
       include_vars:
-        file: "vars/install-on-{{ platform }}.yml"
+        file: "vars/install-on-{{ {{ (platform == 'aws-arm') | ternary('aws', platform) }} }}.yml"
     - name: Set dynamic scale-ci-deploy path
       set_fact:
         dynamic_deploy_path: "{% if lookup('env', 'DYNAMIC_DEPLOY_PATH') %}{{ lookup('env', 'DYNAMIC_DEPLOY_PATH') }}{% else %}scale-ci-{{ openshift_cluster_name }}-{{ platform }}{% endif %}"

--- a/OCP-4.X/roles/openshift-install/defaults/main.yml
+++ b/OCP-4.X/roles/openshift-install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+aws_install_architecture: "amd64"

--- a/OCP-4.X/roles/openshift-install/tasks/main.yml
+++ b/OCP-4.X/roles/openshift-install/tasks/main.yml
@@ -161,7 +161,7 @@
        src: credentials.j2
        dest: "{{ ansible_user_dir }}/.aws/credentials"
 
-  when: platform == "aws"
+  when: platform == "aws" or platform == "aws-arm"
 
 - name: Setting up Azure
   block:
@@ -249,7 +249,7 @@
 
 - name: Setup install-config.yaml
   template:
-    src: install-config-{{ platform }}.yaml.j2
+    src: install-config-{{ (platform == 'aws-arm') | ternary('aws', platform) }}.yaml.j2
     dest: "{{item}}"
   with_items:
     - "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/install-config.yaml"

--- a/OCP-4.X/roles/openshift-install/templates/install-config-aws.yaml.j2
+++ b/OCP-4.X/roles/openshift-install/templates/install-config-aws.yaml.j2
@@ -1,7 +1,8 @@
 apiVersion: {{ openshift_install_apiversion }}
 baseDomain: {{ openshift_base_domain }}
 compute:
-- name: worker
+- architecture: {{ aws_install_architecture }}
+  name: worker
   platform:
    aws:
      type: {{ openshift_worker_instance_type }}
@@ -11,6 +12,7 @@ compute:
        type: {{ openshift_worker_root_volume_type }}
   replicas: {{ openshift_worker_count }}
 ControlPlane:
+  architecture: {{ aws_install_architecture }}
   name: master
   platform:
    aws:

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -63,7 +63,7 @@
         - src: aws-workload-node-machineset.yml.j2
           dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/workload-node-machineset.yml"
           toggle: "{{openshift_toggle_workload_node}}"
-  when: platform == "aws"
+  when: platform == "aws" or platform == "aws-arm"
 
 - name: Azure Block of tasks
   block:

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -4,6 +4,7 @@ aws_profile: "{{ lookup('env', 'AWS_PROFILE')|default('default', true) }}"
 aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
 aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
 aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+aws_install_architecture: "{{ lookup('env', 'AWS_INSTALL_ARCHITECTURE') | default('amd64', true) }}"
 workload_aws_az_suffix: "{{ lookup('env', 'WORKLOAD_AWS_AZ_SUFFIX') | default('d', true) }}"
 
 # Cluster configuration


### PR DESCRIPTION
### Description

scale-ci-deploy changes required to run airflow-kubernetes tests against AWS Graviton2 instances.
See the branch of the same name.

### Fixes
