### PR TITLE
Deploy 2 infra nodes rather than 3

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -240,7 +240,7 @@
 
 - name: Increment expected node count with infra nodes
   set_fact:
-    expected_node_count: "{{expected_node_count|int + 3}}"
+    expected_node_count: "{{expected_node_count|int + 2}}"
   when: openshift_toggle_infra_node|bool
 
 - name: Increment expected node count with workload node

--- a/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
@@ -94,7 +94,7 @@ items:
     name: infra-{{alibaba_region}}b
     namespace: openshift-machine-api
   spec:
-    replicas: 2
+    replicas: 1
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}

--- a/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
@@ -1,4 +1,5 @@
 apiVersion: v1
+kind: List
 items:
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
@@ -69,8 +70,6 @@ items:
               name: {{ user_data_secret }}
         versions:
           kubelet: ""
-  status:
-    replicas: 0
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
   metadata:
@@ -140,78 +139,3 @@ items:
               name: {{ user_data_secret }}
         versions:
           kubelet: ""
-  status:
-    replicas: 0
-- apiVersion: machine.openshift.io/v1beta1
-  kind: MachineSet
-  metadata:
-    creationTimestamp: null
-    labels:
-      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-      {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-      {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: infra-{{aws_region.stdout}}c
-    namespace: openshift-machine-api
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}c
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{aws_region.stdout}}c
-      spec:
-        metadata:
-          creationTimestamp: null
-          labels:
-            node-role.kubernetes.io/infra: ""
-        providerSpec:
-          value:
-            ami:
-              id: {{ami_id.stdout}}
-            apiVersion: awsproviderconfig.openshift.io/v1beta1
-            blockDevices:
-            - ebs:
-                iops: {{openshift_infra_node_volume_iops}}
-                volumeSize: {{openshift_infra_node_volume_size}}
-                volumeType: {{openshift_infra_node_volume_type}}
-            credentialsSecret:
-              name: aws-cloud-credentials
-            deviceIndex: 0
-            iamInstanceProfile:
-              id: {{cluster_name.stdout}}-worker-profile
-            instanceType: {{openshift_infra_node_instance_type}}
-            kind: AWSMachineProviderConfig
-            metadata:
-              creationTimestamp: null
-            placement:
-              availabilityZone: {{aws_region.stdout}}c
-              region: {{aws_region.stdout}}
-            publicIp: false
-            securityGroups:
-            - filters:
-              - name: tag:Name
-                values:
-                - {{cluster_name.stdout}}-worker-sg
-            subnet:
-              filters:
-              - name: tag:Name
-                values:
-                - {{cluster_name.stdout}}-private-{{aws_region.stdout}}c
-            tags:
-            - name: kubernetes.io/cluster/{{cluster_name.stdout}}
-              value: owned
-            userDataSecret:
-              name: {{ user_data_secret }}
-        versions:
-          kubelet: ""
-  status:
-    replicas: 0
-kind: List
-metadata: {}

--- a/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
@@ -1,4 +1,5 @@
 apiVersion: v1
+kind: List
 items:
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
@@ -65,8 +66,6 @@ items:
             vmSize: {{openshift_infra_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "1"
-  status:
-    replicas: 0
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
   metadata:
@@ -132,74 +131,3 @@ items:
             vmSize: {{openshift_infra_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "2"
-  status:
-    replicas: 0
-- apiVersion: machine.openshift.io/v1beta1
-  kind: MachineSet
-  metadata:
-    creationTimestamp: null
-    labels:
-      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-      {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-      {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-    name: infra-{{azure_location.stdout}}3
-    namespace: openshift-machine-api
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}3
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: infra-{{azure_location.stdout}}3
-      spec:
-        metadata:
-          creationTimestamp: null
-          labels:
-            node-role.kubernetes.io/infra: ""
-        providerSpec:
-          value:
-            apiVersion: azureproviderconfig.openshift.io/v1beta1
-            credentialsSecret:
-              name: azure-cloud-credentials
-              namespace: openshift-machine-api
-            image:
-              offer: ""
-              publisher: ""
-              resourceID: /resourceGroups/{{cluster_name.stdout}}-rg/providers/Microsoft.Compute/images/{{cluster_name.stdout}}
-              sku: ""
-              version: ""
-            internalLoadBalancer: ""
-            kind: AzureMachineProviderSpec
-            location: centralus
-            managedIdentity: {{cluster_name.stdout}}-identity
-            metadata:
-              creationTimestamp: null
-            natRule: null
-            networkResourceGroup: ""
-            osDisk:
-              diskSizeGB: {{openshift_infra_node_volume_size}}
-              managedDisk:
-                storageAccountType: {{openshift_infra_node_volume_type}}
-              osType: Linux
-            publicIP: false
-            publicLoadBalancer: ""
-            resourceGroup: {{cluster_name.stdout}}-rg
-            sshPrivateKey: ""
-            sshPublicKey: ""
-            subnet: {{cluster_name.stdout}}-worker-subnet
-            userDataSecret:
-              name: {{ user_data_secret }}
-            vmSize: {{openshift_infra_node_vm_size}}
-            vnet: {{cluster_name.stdout}}-vnet
-            zone: "3"
-  status:
-    replicas: 0
-kind: List
-metadata: {}

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -1,4 +1,5 @@
 apiVersion: v1
+kind: List
 items:
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
@@ -61,8 +62,6 @@ items:
             userDataSecret:
               name: {{ user_data_secret }}
             zone: {{ gcp_region }}-a
-  status:
-    replicas: 1
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
   metadata:
@@ -124,70 +123,3 @@ items:
             userDataSecret:
               name: {{ user_data_secret }}
             zone: {{ gcp_region }}-b
-  status:
-    replicas: 1
-- apiVersion: machine.openshift.io/v1beta1
-  kind: MachineSet
-  metadata:
-    generation: 1
-    labels:
-      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
-    name: {{cluster_name.stdout}}-infra-c
-    namespace: openshift-machine-api
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-        {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
-          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
-      spec:
-        metadata:
-          creationTimestamp: null
-          labels:
-            node-role.kubernetes.io/infra: ""
-        providerSpec:
-          value:
-            apiVersion: gcpprovider.openshift.io/v1beta1
-            canIPForward: false
-            credentialsSecret:
-              name: gcp-cloud-credentials
-            deletionProtection: false
-            disks:
-            - autoDelete: true
-              boot: true
-              image: {{worker_machineset_image.stdout}}
-              labels: null
-              sizeGb: {{openshift_infra_node_volume_size}}
-              type: {{openshift_infra_node_volume_type}}
-            kind: GCPMachineProviderSpec
-            machineType: {{openshift_infra_node_instance_type}}
-            metadata:
-              creationTimestamp: null
-            networkInterfaces:
-            - network: {{cluster_name.stdout}}-network
-              subnetwork: {{cluster_name.stdout}}-worker-subnet
-            projectID: {{ gcp_project }}
-            region: {{ gcp_region }}
-            serviceAccounts:
-            - email: {{cluster_name.stdout}}-w@{{ gcp_service_account_email }}
-              scopes:
-              - https://www.googleapis.com/auth/cloud-platform
-            tags:
-            - {{cluster_name.stdout}}-worker
-            userDataSecret:
-              name: {{ user_data_secret }}
-            zone: {{ gcp_region }}-c
-  status:
-    replicas: 1
-kind: List
-metadata: {}

--- a/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
@@ -1,4 +1,5 @@
 apiVersion: v1
+kind: List
 items:
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
@@ -11,7 +12,7 @@ items:
     name: infra
     namespace: openshift-machine-api
   spec:
-    replicas: 3
+    replicas: 2
     selector:
       matchLabels:
         {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
@@ -60,7 +61,3 @@ items:
               name: {{ user_data_secret }}
         versions:
           kubelet: ""
-  status:
-    replicas: 0
-kind: List
-metadata: {}


### PR DESCRIPTION
### Description

We no longer need 3 infra nodes. We needed it originally b/c alertManager had 3 replicas, now it has 2.

cc: @jtaleric @dry923 