### PR TITLE
support ovn_ic and cno image override

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -186,26 +186,55 @@
   block:
   - name: Scale CVO Down for OVNKubernetes image patching
     command: oc scale -n openshift-cluster-version deployment.apps/cluster-version-operator --replicas=0
-  
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+
   - name: Patch new OVNKubernetes Image
     command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}} RELEASE_VERSION="5.0.0"
- 
-  - name: Get ovnkube-node pod
-    shell: oc get pods -n {{ ovn_namespace }} | tail -n1 | awk '{print $1}'
-    register: ovnkube_node_pod
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+    when: openshift_ovn_image != ''
 
-  - name: Check one ovnkube-node pod to see if ovn image has been updated
-    shell: oc get pod -n {{ ovn_namespace }} {{ovnkube_node_pod.stdout}} -o json| jq '.spec.containers[] | select(.name=="ovnkube-node").image'
-    register: ovnkube_node_image
-    until: (ovnkube_node_image.stdout) == (openshift_ovn_image) or (ovnkube_node_image.stdout) == ""
+  - name: Patch new CNO Image
+    command: oc -n openshift-network-operator set image deployment/network-operator network-operator={{openshift_cno_image}}
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+    when: openshift_cno_image != ''
+
+  - name: wait for 1 minute before checking for rollout
+    pause:
+      minutes: 1
+
+  - name: Wait till we get ovnkube DS
+    vars:
+      ovnkube_ds_name: "daemonset.apps/ovnkube-node"
+    shell: oc -n {{ ovn_namespace }} get ds ovnkube-node -o NAME --no-headers=true --ignore-not-found=true
+    register: ovnkube_ds
+    until: ovnkube_ds.stdout == ovnkube_ds_name
     delay: 1
     retries: 600
-  
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+
   - name: Wait for OVNK new node images to roll out
-    command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-node
-  
+    command: oc -n {{ ovn_namespace }} rollout status ds/ovnkube-node
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+
   - name: Wait for OVNK new master images to roll out
-    command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-master
+    command: oc -n {{ ovn_namespace }} rollout status ds/ovnkube-master
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+
+  - name: check if the ds has the new OVN image
+    shell: oc -n {{ ovn_namespace }} get ds ovnkube-node -o json | jq -r '.spec.template.spec.containers[] | select(.name=="ovnkube-node").image'
+    register: ovnkube_node_image
+    until: (ovnkube_node_image.stdout|regex_replace('\"', '') == openshift_ovn_image) or (ovnkube_node_image.stdout == "")
+    delay: 1
+    retries: 10
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
+    when: openshift_ovn_image != ''
   
   - name: OVN SBDB block
     block:
@@ -214,13 +243,13 @@
     
     - name: Wait for OVNK sbdb-relay images to roll out
       command: oc rollout status -n {{ ovn_namespace }} deployment.apps/ovnkube-sbdb-relay
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
     
     - name: Verify ovnkube-sbdb-relay connectivity
       script: sbdb-relay.sh verify
     when: openshift_toggle_ovn_relay|bool
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-  when: openshift_toggle_ovn_patch|bool
+  when: openshift_ovn_image != '' or openshift_cno_image != ''
 
 - name: Create machinesets
   shell: |

--- a/OCP-4.X/vars/install-common-vars.yml
+++ b/OCP-4.X/vars/install-common-vars.yml
@@ -118,8 +118,9 @@ fips: "{{ lookup('env', 'FIPS')|default(false, true) }}"
 es_server: "{{ lookup('env', 'ES_SERVER')|default('https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443', true) }}"
 
 # OVNKubernetes image patch
-openshift_toggle_ovn_patch: "{{ lookup('env', 'OVN_PATCH')|default(false, true) }}"
-openshift_ovn_image: "{{ lookup('env', 'OVN_IMAGE')|default('', true) }}"
+openshift_ovn_ic: "{{ lookup('env', 'OPENSHIFT_OVN_IC')|default(false, true) }}"
+openshift_ovn_image: "{{ lookup('env', 'OPENSHIFT_OVN_IMAGE')|default('', true) }}"
+openshift_cno_image: "{{ lookup('env', 'OPENSHIFT_CNO_IMAGE')|default('', true) }}"
 
 # RHACS
 rhacs_enable: "{{ lookup('env', 'RHACS_ENABLE')|default(false, true) }}"

--- a/docs/ocp4_alibaba.md
+++ b/docs/ocp4_alibaba.md
@@ -141,10 +141,14 @@ Default: `2Gi`
 Default: `false`
 Toggle the deployment of the OVN SBSB relay.
 
-### OVN_PATCH
+### OVN_IC
 Default: `false`
-Toggle to patch and replace the default OVN deployment image.
+OVN is using differnt naming convention for pods when OVN Interconnect is enabled. This flag helps in verifying if OVN_IMAGE is properly applied on relevant pods or not.
 
 ### OVN_IMAGE
 Default: `nil`
-The OVN image that we will use to replace the default, requires `OVN_PATCH` to be `true`.
+The OVN image that we will use to replace the default.
+
+### CNO_IMAGE
+Default: `nil`
+The CNO image that we will use to replace the default.

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -155,13 +155,17 @@ Default: `2Gi`
 Default: `false`
 Toggle the deployment of the OVN SBSB relay.
 
-### OVN_PATCH
+### OVN_IC
 Default: `false`
-Toggle to patch and replace the default OVN deployment image.
+OVN is using differnt naming convention for pods when OVN Interconnect is enabled. This flag helps in verifying if OVN_IMAGE is properly applied on relevant pods or not.
 
 ### OVN_IMAGE
 Default: `nil`
-The OVN image that we will use to replace the default, requires `OVN_PATCH` to be `true`.
+The OVN image that we will use to replace the default.
+
+### CNO_IMAGE
+Default: `nil`
+The CNO image that we will use to replace the default.
 
 ### WORKLOAD_AWS_AZ_SUFFIX
 Default: `d`


### PR DESCRIPTION
1. In Ansible, the environment directive should be defined within a task block if you want it to be applied to that specific task.
2. Wait for 1 minute before checking for rollout status (sometimes rollout returns immediately without applying changes)
3. In OVN-IC, kube node pods are renamed as "ovnkube" and master pods as "ovnkube-control-plane". So we will check for the image in newly deployed pods after rollout.
4.  need to remove quotes ("") from ovnkube_node_image.stdout before
comparing with openshift_ovn_image

How to enable OVN IC?
As nightly images are already having ovn ic code, no need to change OVN_IMAGE. Use quay.io/itssurya/dev-images:ic-scale-cno-v3 CNO image to get IC environment by setting below env variables OVN_PATCH=true
OVN_IC=true
CNO_IMAGE=quay.io/itssurya/dev-images:ic-scale-cno-v3

### Description

### Fixes
