### PR TITLE
patch ovn and cno images independently

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -187,6 +187,10 @@
   - name: Scale CVO Down for OVNKubernetes image patching
     command: oc scale -n openshift-cluster-version deployment.apps/cluster-version-operator --replicas=0
   
+  - name: Save name of an ovnkube-master pod
+    shell: oc get pods -n {{ ovn_namespace }} | grep ovnkube-master | tail -n1 | awk '{print $1}'
+    register: ovnkube_master_pod
+
   - name: Patch new Cluster Network Operator Image
     block:
     - name: Patch new CNO Image
@@ -213,8 +217,24 @@
   - name: Wait for OVNK new node images to roll out
     command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-node
   
+  - name: Wait for OVNK master pod to terminate
+    shell: oc get pods -n {{ ovn_namespace }} | grep {{ovnkube_master_pod.stdout}} || true
+    register: ovnkube_master_pod2
+    until: (ovnkube_master_pod2.stdout) == ""
+    delay: 1
+    retries: 600
+
+  - name: Determine if the cluster uses OVN-IC topology
+    shell: oc get pods -n {{ ovn_namespace }} | grep ovnkube-control-plane | tail -n1 | awk '{print $1}'
+    register: ovnkube_cp_pod
+
   - name: Wait for OVNK new master images to roll out
     command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-master
+    when: ovnkube_cp_pod == ""
+
+  - name: Wait for OVNK new IC controller images to roll out
+    command: oc rollout status -n {{ ovn_namespace }} deployment/ovnkube-control-plane
+    when: ovnkube_cp_pod != ""
   
   - name: OVN SBDB block
     block:

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -201,18 +201,21 @@
     when: openshift_toggle_cno_patch|bool
 
   - name: Patch new OVNKubernetes Image
-    command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}} RELEASE_VERSION="5.0.0"
+    block:
+    - name: Patch new OVNKubernetes Image
+      command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}} RELEASE_VERSION="5.0.0"
  
-  - name: Get ovnkube-node pod
-    shell: oc get pods -n {{ ovn_namespace }} | tail -n1 | awk '{print $1}'
-    register: ovnkube_node_pod
+    - name: Get ovnkube-node pod
+      shell: oc get pods -n {{ ovn_namespace }} | tail -n1 | awk '{print $1}'
+      register: ovnkube_node_pod
 
-  - name: Check one ovnkube-node pod to see if ovn image has been updated
-    shell: oc get pod -n {{ ovn_namespace }} {{ovnkube_node_pod.stdout}} -o json| jq '.spec.containers[] | select(.name=="ovnkube-node").image'
-    register: ovnkube_node_image
-    until: (ovnkube_node_image.stdout) == (openshift_ovn_image) or (ovnkube_node_image.stdout) == ""
-    delay: 1
-    retries: 600
+    - name: Check one ovnkube-node pod to see if ovn image has been updated
+      shell: oc get pod -n {{ ovn_namespace }} {{ovnkube_node_pod.stdout}} -o json| jq '.spec.containers[] | select(.name=="ovnkube-node").image'
+      register: ovnkube_node_image
+      until: (ovnkube_node_image.stdout) == (openshift_ovn_image) or (ovnkube_node_image.stdout) == ""
+      delay: 1
+      retries: 600
+    when: openshift_toggle_ovn_patch|bool
   
   - name: Wait for OVNK new node images to roll out
     command: oc rollout status -n {{ ovn_namespace }} ds/ovnkube-node
@@ -249,7 +252,7 @@
     when: openshift_toggle_ovn_relay|bool
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
-  when: openshift_toggle_ovn_patch|bool
+  when: openshift_toggle_ovn_patch|bool or openshift_toggle_cno_patch|bool
 
 - name: Create machinesets
   shell: |


### PR DESCRIPTION
Currently we can't patch cno alone as it depends on openshift_ovn_image.
This patch allow below combination of patching cno and ovn images
1. apply only ovnk image
2. apply only cno image (this is the way to enable ic on nightly)
3. apply both ovnk and cno image