### PR TITLE
Apply taint and tolerations to infra

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -290,13 +290,6 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: (openshift_toggle_infra_node|bool == true or openshift_toggle_workload_node|bool == true)
 
-- name: Relabel the infra nodes
-  shell: |
-    oc label nodes --overwrite -l 'node-role.kubernetes.io/infra=' node-role.kubernetes.io/worker-
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-  when: openshift_toggle_infra_node|bool
-
 - name: Relabel the workload node
   shell: |
     oc label nodes --overwrite -l 'node-role.kubernetes.io/workload=' node-role.kubernetes.io/worker-
@@ -382,12 +375,12 @@
     - namespace: openshift-ingress-operator
       object: ingresscontrollers/default
       patch: |
-        '{"spec": {"nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}}}}}'
+        '{"spec":{"nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}},"tolerations": [{"effect":"NoSchedule","key": "node-role.kubernetes.io/infra","value": "reserved"},{"effect":"NoExecute","key": "node-role.kubernetes.io/infra","value": "reserved"}]}}}'
       type: "--type merge"
     - namespace: openshift-image-registry
       object: configs.imageregistry.operator.openshift.io/cluster
       patch: |
-        '{"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""}}}'
+        '{"spec":{"nodeSelector": {"node-role.kubernetes.io/infra": ""},"tolerations": [{"effect":"NoSchedule","key": "node-role.kubernetes.io/infra","value": "reserved"},{"effect":"NoExecute","key": "node-role.kubernetes.io/infra","value": "reserved"}]}}'
       type: "--type merge"
     # Monitoring (Relocate cluster-monitoring-operator from worker nodes) - Requires CVO overriding
     #- namespace: openshift-monitoring

--- a/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/alibaba-infra-node-machineset.yml.j2
@@ -81,8 +81,12 @@ items:
             vpcId: ""
             zoneId: {{alibaba_region}}a
           taints:
-          - key: node-role.kubernetes.io/infra
-            effect: NoSchedule
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/infra
+            value: reserved
+          - effect: NoExecute
+            key: node-role.kubernetes.io/infra
+            value: reserved
 - apiVersion: machine.openshift.io/v1beta1
   kind: MachineSet
   metadata:
@@ -162,5 +166,9 @@ items:
             vpcId: ""
             zoneId: {{alibaba_region}}b
           taints:
-          - key: node-role.kubernetes.io/infra
-            effect: NoSchedule
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/infra
+            value: reserved
+          - effect: NoExecute
+            key: node-role.kubernetes.io/infra
+            value: reserved

--- a/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
@@ -30,6 +30,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             ami:
@@ -99,6 +106,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             ami:

--- a/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
@@ -30,6 +30,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             apiVersion: azureproviderconfig.openshift.io/v1beta1
@@ -95,6 +102,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             apiVersion: azureproviderconfig.openshift.io/v1beta1

--- a/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -8,6 +8,13 @@ data:
       configReloaderBaseImage: quay.io/coreos/configmap-reload
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
     prometheusK8s:
 {% if thanos_enable %}
       externalLabels:
@@ -22,6 +29,13 @@ data:
       baseImage: openshift/prometheus
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
       volumeClaimTemplate:
         spec:
           storageClassName: {{openshift_prometheus_storage_class}}
@@ -32,6 +46,13 @@ data:
       baseImage: openshift/prometheus-alertmanager
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
       volumeClaimTemplate:
         spec:
           storageClassName: {{openshift_alertmanager_storage_class}}
@@ -46,15 +67,36 @@ data:
       baseImage: quay.io/coreos/kube-state-metrics
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
     grafana:
       baseImage: grafana/grafana
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
     auth:
       baseImage: openshift/oauth-proxy
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/infra
+        value: reserved
+        effect: NoExecute
 metadata:
   name: cluster-monitoring-config
   namespace: openshift-monitoring

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -30,6 +30,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             apiVersion: gcpprovider.openshift.io/v1beta1
@@ -91,6 +98,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             apiVersion: gcpprovider.openshift.io/v1beta1

--- a/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
@@ -30,6 +30,13 @@ items:
           creationTimestamp: null
           labels:
             node-role.kubernetes.io/infra: ""
+        taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          value: reserved
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          value: reserved
         providerSpec:
           value:
             apiVersion: openstackproviderconfig.k8s.io/v1alpha1


### PR DESCRIPTION
Infra nodes must have node-role.kubernetes.io/worker=”” label as MCP considers nodes with only this label for upgrades and migration.

We apply taints to infra nodes to avoid hosting workloads and then tolerations to specific workloads which should be hosted on these nodes.

OVNK Migration was failing without this change https://issues.redhat.com/browse/PERFSCALE-2351?focusedId=22752673&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22752673
