### PR TITLE
avoid RELEASE_VERSION override during ovn patching

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -203,7 +203,7 @@
   - name: Patch new OVNKubernetes Image
     block:
     - name: Patch new OVNKubernetes Image
-      command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}} RELEASE_VERSION="5.0.0"
+      command: oc -n openshift-network-operator set env deployment.apps/network-operator OVN_IMAGE={{openshift_ovn_image}}
  
     - name: Get ovnkube-node pod
       shell: oc get pods -n {{ ovn_namespace }} | tail -n1 | awk '{print $1}'


### PR DESCRIPTION
network operator is stuck in CrashLoppBackOff state when we are overriding RELEASE_VERSION during ovn patching. The purpose of this ansible task is to only override OVN_MAGE, we will avoid changing RELEASE_VERSION in this task

Fixes #218

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
